### PR TITLE
s/Hudson/Jenkins/ in build agent

### DIFF
--- a/src/main/java/org/jfrog/hudson/gradle/GradleInitScriptWriter.java
+++ b/src/main/java/org/jfrog/hudson/gradle/GradleInitScriptWriter.java
@@ -179,7 +179,7 @@ public class GradleInitScriptWriter {
         if (StringUtils.isNotBlank(svnRevision)) {
             ArtifactoryPluginUtils.addProperty(stringBuilder, BuildInfoProperties.PROP_VCS_REVISION, svnRevision);
         }
-        ArtifactoryPluginUtils.addProperty(stringBuilder, BuildInfoProperties.PROP_AGENT_NAME, "Hudson");
+        ArtifactoryPluginUtils.addProperty(stringBuilder, BuildInfoProperties.PROP_AGENT_NAME, "Jenkins");
         ArtifactoryPluginUtils
                 .addProperty(stringBuilder, BuildInfoProperties.PROP_AGENT_VERSION, build.getHudsonVersion());
         Cause.UpstreamCause parent = ActionableHelper.getUpstreamCause(build);

--- a/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator.java
@@ -248,7 +248,7 @@ public class ArtifactoryIvyConfigurator extends AntIvyBuildWrapper implements De
                         artifactoryServer);
                 env.put(ClientProperties.PROP_PUBLISH_USERNAME, preferredDeployer.getUsername());
                 env.put(ClientProperties.PROP_PUBLISH_PASSWORD, preferredDeployer.getPassword());
-                env.put(BuildInfoProperties.PROP_AGENT_NAME, "Hudson");
+                env.put(BuildInfoProperties.PROP_AGENT_NAME, "Jenkins");
                 env.put(BuildInfoProperties.PROP_AGENT_VERSION, build.getHudsonVersion());
                 env.put(BuildInfoProperties.PROP_BUILD_NUMBER, build.getNumber() + "");
                 env.put(BuildInfoProperties.PROP_BUILD_NAME, build.getProject().getName());

--- a/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator.java
+++ b/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator.java
@@ -335,7 +335,7 @@ public class ArtifactoryMaven3Configurator extends BuildWrapper implements Deplo
 
         props.put(BuildInfoProperties.PROP_PRINCIPAL, userName);
 
-        props.put(BuildInfoProperties.PROP_AGENT_NAME, "Hudson");
+        props.put(BuildInfoProperties.PROP_AGENT_NAME, "Jenkins");
         props.put(BuildInfoProperties.PROP_AGENT_VERSION, build.getHudsonVersion());
 
         props.put(ClientProperties.PROP_CONTEXT_URL, selectedArtifactoryServer.getUrl());


### PR DESCRIPTION
Fixing agent to say Jenkins, rather than Hudson, after seeing it show up at the CI Summit. =)
