### PR TITLE
Make Artifactory respect Jenkins' artifact retention policy, if set

### DIFF
--- a/src/main/java/org/jfrog/hudson/util/BuildRetentionFactory.java
+++ b/src/main/java/org/jfrog/hudson/util/BuildRetentionFactory.java
@@ -27,11 +27,12 @@ public class BuildRetentionFactory {
             return buildRetention;
         }
         if (rotator.getNumToKeep() > -1) {
-            buildRetention.setCount(rotator.getNumToKeep());
+            buildRetention.setCount((rotator.getArtifactNumToKeep() > 0 ? rotator.getArtifactNumToKeep() : rotator.getNumToKeep()));
         }
         if (rotator.getDaysToKeep() > -1) {
             Calendar calendar = Calendar.getInstance();
-            calendar.add(Calendar.DAY_OF_YEAR, -rotator.getDaysToKeep());
+            calendar.add(Calendar.DAY_OF_YEAR, 
+                    -(rotator.getArtifactDaysToKeep() > 0 ? rotator.getArtifactDaysToKeep() : rotator.getDaysToKeep()));
             buildRetention.setMinimumBuildDate(new Date(calendar.getTimeInMillis()));
         }
         List<String> notToBeDeleted = ExtractorUtils.getBuildNumbersNotToBeDeleted(build);


### PR DESCRIPTION
In my Maven projects, if I configure Jenkins to retain e.g. 6 months' of build logs, but only artifacts for the last 10 builds, Artifactory retains 6 months' worth of snapshots, which is not what I would expect to happen. The change is to accept Jenkins' artifact retention policy, if set, for the purpose of setting retention on the Artifactory side.
