### PR TITLE
MatrixProject Support

### DIFF
--- a/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
@@ -5,6 +5,8 @@ import hudson.Launcher;
 import hudson.model.*;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
+import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixProject.DescriptorImpl;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
@@ -313,7 +315,7 @@ public class ArtifactoryGenericConfigurator extends BuildWrapper implements Depl
 
         @Override
         public boolean isApplicable(AbstractProject<?, ?> item) {
-            return item.getClass().isAssignableFrom(FreeStyleProject.class);
+            return item.getClass().isAssignableFrom(FreeStyleProject.class) || MatrixProject.class.equals(item.getClass());
         }
 
         @Override

--- a/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
@@ -24,6 +24,8 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.*;
 import hudson.model.listeners.RunListener;
+import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixProject.DescriptorImpl;
 import hudson.plugins.gradle.Gradle;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
@@ -564,7 +566,7 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
 
         @Override
         public boolean isApplicable(AbstractProject<?, ?> item) {
-            return item.getClass().isAssignableFrom(FreeStyleProject.class);
+            return item.getClass().isAssignableFrom(FreeStyleProject.class) || MatrixProject.class.equals(item.getClass());
         }
 
         @Override

--- a/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
@@ -21,6 +21,8 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.*;
+import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixProject.DescriptorImpl;
 import hudson.remoting.Which;
 import hudson.tasks.Ant;
 import hudson.tasks.BuildWrapper;
@@ -422,7 +424,7 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
 
         @Override
         public boolean isApplicable(AbstractProject<?, ?> item) {
-            return item.getClass().isAssignableFrom(FreeStyleProject.class);
+            return item.getClass().isAssignableFrom(FreeStyleProject.class) || MatrixProject.class.equals(item.getClass());
         }
 
         @Override

--- a/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator.java
+++ b/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator.java
@@ -19,6 +19,8 @@ package org.jfrog.hudson.maven3;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.*;
+import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixProject.DescriptorImpl;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.util.FormValidation;
@@ -376,7 +378,7 @@ public class ArtifactoryMaven3Configurator extends BuildWrapper implements Deplo
 
         @Override
         public boolean isApplicable(AbstractProject<?, ?> item) {
-            return item.getClass().isAssignableFrom(FreeStyleProject.class);
+            return item.getClass().isAssignableFrom(FreeStyleProject.class) || MatrixProject.class.equals(item.getClass());
         }
 
         @Override


### PR DESCRIPTION
Add multi-configuration MatrixProject support to Generic, Ant/Ivy,
Gradle, and Maven3 configurators so that each job spawned by a Multi-Configuration project can upload to Artifactory.
