### PR TITLE
Made it configurable for the tag names to include the root module artifactId

### DIFF
--- a/src/main/java/org/jfrog/hudson/release/maven/MavenReleaseAction.java
+++ b/src/main/java/org/jfrog/hudson/release/maven/MavenReleaseAction.java
@@ -203,11 +203,16 @@ public class MavenReleaseAction extends ReleaseAction<MavenModuleSet, MavenRelea
         MavenReleaseWrapper wrapper = getWrapper();
         String baseTagUrl = wrapper.getTagPrefix();
         StringBuilder sb = new StringBuilder(getBaseTagUrlAccordingToScm(baseTagUrl));
-        MavenModule rootModule = getRootModule();
-        if (rootModule != null) {
-            sb.append(rootModule.getModuleName().artifactId).append("-").append(getDefaultReleaseVersion());
-        }
-        return sb.toString();
+        Boolean prependArtifactId = getDefaultPrependArtifactId();
+        if (prependArtifactId) {
+	        MavenModule rootModule = getRootModule();
+	        if (rootModule != null) {
+	            sb.append(rootModule.getModuleName().artifactId).append("-").append(getDefaultReleaseVersion());
+	        }
+        } else {
+        	sb.append(getDefaultReleaseVersion());
+        }        	
+    	return sb.toString();
     }
 
     private String getDefaultTagComment() {
@@ -231,5 +236,11 @@ public class MavenReleaseAction extends ReleaseAction<MavenModuleSet, MavenRelea
             return null;
         }
         return publisher.getRepositoryKey();
+    }
+    
+    private Boolean getDefaultPrependArtifactId() {
+    	MavenReleaseWrapper wrapper = getWrapper();
+    	Boolean prependArtifactId = wrapper.getPrependArtifactId();
+    	return prependArtifactId;
     }
 }

--- a/src/main/java/org/jfrog/hudson/release/maven/MavenReleaseWrapper.java
+++ b/src/main/java/org/jfrog/hudson/release/maven/MavenReleaseWrapper.java
@@ -63,16 +63,18 @@ public class MavenReleaseWrapper extends BuildWrapper {
     private String releaseBranchPrefix;
     private String alternativeGoals;
     private String defaultVersioning;
+    private Boolean prependArtifactId;
 
     private transient ScmCoordinator scmCoordinator;
 
     @DataBoundConstructor
     public MavenReleaseWrapper(String releaseBranchPrefix, String tagPrefix, String alternativeGoals,
-            String defaultVersioning) {
+            String defaultVersioning, Boolean prependArtifactId) {
         this.releaseBranchPrefix = releaseBranchPrefix;
         this.tagPrefix = tagPrefix;
         this.alternativeGoals = alternativeGoals;
         this.defaultVersioning = defaultVersioning;
+        this.prependArtifactId = prependArtifactId;
     }
 
     public String getTagPrefix() {
@@ -112,6 +114,16 @@ public class MavenReleaseWrapper extends BuildWrapper {
     public void setDefaultVersioning(String defaultVersioning) {
         this.defaultVersioning = defaultVersioning;
     }
+
+    @SuppressWarnings({"UnusedDeclaration"})
+    public Boolean getPrependArtifactId() {
+		return prependArtifactId;
+	}
+
+    @SuppressWarnings({"UnusedDeclaration"})
+	public void setPrependArtifactId(Boolean prependArtifactId) {
+		this.prependArtifactId = prependArtifactId;
+	}    
 
     @Override
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener)

--- a/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseWrapper/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseWrapper/config.jelly
@@ -18,4 +18,8 @@
         <f:textbox name="alternativeGoals" value="${instance.alternativeGoals}"
                    default="${jenkins.artifactory.release.maven.alternativeGoalsDefault}"/>
     </f:entry>
+  	<f:entry title="">
+	    <f:checkbox name="prependArtifactId" checked="${instance.prependArtifactId}" default="true"
+	     			title="Include root module artifactId in the tag name?"/>
+	</f:entry>
 </j:jelly>


### PR DESCRIPTION
This change has stemmed from the need to create tags having only the version in their name. So I have made this configurable in the job configuration screen (enabled by default).

When "Include root module artifactId in the tag name?" checkbox is unticked, tag names will not have the artifactId included by default on the release staging screen.

Regards,
Sergey
