### PR TITLE
[FIXED HAP-484] When detailed information about the artifactory instance...

### DIFF
--- a/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
@@ -207,7 +207,7 @@ public class ArtifactoryGenericConfigurator extends BuildWrapper implements Depl
 
     @Override
     public Collection<? extends Action> getProjectActions(AbstractProject project) {
-        return ActionableHelper.getArtifactoryProjectAction(details.getArtifactoryUrl(), project);
+        return ActionableHelper.getArtifactoryProjectAction(getArtifactoryUrl(), project);
     }
 
     @Override


### PR DESCRIPTION
... is null, the job would fail to load. Also if the job is in a folder the entire folder would fail to load.
