### PR TITLE
Update compatability to all "hudson.model.Project"s 

### DIFF
--- a/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
@@ -315,7 +315,7 @@ public class ArtifactoryGenericConfigurator extends BuildWrapper implements Depl
 
         @Override
         public boolean isApplicable(AbstractProject<?, ?> item) {
-            return item.getClass().isAssignableFrom(FreeStyleProject.class) || MatrixProject.class.equals(item.getClass());
+            return item.getClass().isAssignableFrom(Project.class) || MatrixProject.class.equals(item.getClass());
         }
 
         /**


### PR DESCRIPTION
Add support for all types of hudson.model.Project and hudson.matrix.MatrixProject instead of just FreeStyle Projects. 
This is in need for supporting https://github.com/alexouzounis/jenkins-inheritance-plugin
