### PR TITLE
Fixes Jenkins-27221

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,474 +1,472 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-~ Copyright (C) 2011 JFrog Ltd.
-~
-~ Licensed under the Apache License, Version 2.0 (the "License");
-~ you may not use this file except in compliance with the License.
-~ You may obtain a copy of the License at
-~
-~ http://www.apache.org/licenses/LICENSE-2.0
-~
-~ Unless required by applicable law or agreed to in writing, software
-~ distributed under the License is distributed on an "AS IS" BASIS,
-~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-~ See the License for the specific language governing permissions and
-~ limitations under the License.
-~test
---><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-<modelVersion>4.0.0</modelVersion>
-<parent>
-	<groupId>org.jenkins-ci.plugins</groupId>
-	<artifactId>plugin</artifactId>
-<!-- 	<version>1.521</version> -->
-	<version>1.532</version>
-	<!-- <version>1.615</version> -->
-</parent>
+  ~ Copyright (C) 2011 JFrog Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~test
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>1.521</version>
+    </parent>
 
-<artifactId>artifactory</artifactId>
-<version>2.3.1-SNAPSHOT</version>
-<packaging>hpi</packaging>
-<name>Jenkins Artifactory Plugin</name>
-<description>Integrates Artifactory to Jenkins</description>
-<url>http://wiki.jenkins-ci.org/display/JENKINS/Artifactory+Plugin</url>
+    <artifactId>artifactory</artifactId>
+    <version>2.3.1-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <name>Jenkins Artifactory Plugin</name>
+    <description>Integrates Artifactory to Jenkins</description>
+    <url>http://wiki.jenkins-ci.org/display/JENKINS/Artifactory+Plugin</url>
 
-<properties>
-	<buildinfo.version>2.5.0</buildinfo.version>
-	<buildinfo.maven3.version>2.5.0</buildinfo.maven3.version>
-	<buildinfo.gradle.version>3.1.0</buildinfo.gradle.version>
-	<buildinfo.ivy.version>2.5.0</buildinfo.ivy.version>
-	<maven-release-plugin.version>2.2</maven-release-plugin.version>
-</properties>
+    <properties>
+        <buildinfo.version>2.5.0</buildinfo.version>
+        <buildinfo.maven3.version>2.5.0</buildinfo.maven3.version>
+        <buildinfo.gradle.version>3.1.0</buildinfo.gradle.version>
+        <buildinfo.ivy.version>2.5.0</buildinfo.ivy.version>
+        <maven-release-plugin.version>2.2</maven-release-plugin.version>
+    </properties>
 
-<developers>
-	<developer>
-	<id>yossis</id>
-	<name>Yossi Shaul</name>
-	<email>yossis@jfrog.org</email>
-	<roles>
-		<role>Lead Developer</role>
-	</roles>
-	</developer>
-</developers>
+    <developers>
+        <developer>
+            <id>yossis</id>
+            <name>Yossi Shaul</name>
+            <email>yossis@jfrog.org</email>
+            <roles>
+                <role>Lead Developer</role>
+            </roles>
+        </developer>
+    </developers>
 
-<organization>
-	<name>JFrog</name>
-	<url>http://www.jfrog.org</url>
-</organization>
+    <organization>
+        <name>JFrog</name>
+        <url>http://www.jfrog.org</url>
+    </organization>
 
-<issueManagement>
-	<system>jira</system>
-	<url>http://issues.jfrog.org/jira/browse/HAP</url>
-</issueManagement>
+    <issueManagement>
+        <system>jira</system>
+        <url>http://issues.jfrog.org/jira/browse/HAP</url>
+    </issueManagement>
 
-<licenses>
-	<license>
-	<name>The Apache Software License, Version 2.0</name>
-	<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-	<distribution>repo</distribution>
-	</license>
-</licenses>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-<dependencies>
-	<dependency>
-	<groupId>org.jenkins-ci.main</groupId>
-	<artifactId>maven-plugin</artifactId>
-	<version>${project.parent.version}</version>
-	<optional>true</optional>
-	</dependency>
-	<dependency>
-	<groupId>org.jenkins-ci.plugins</groupId>
-	<artifactId>subversion</artifactId>
-	<version>2.0</version>
-	<optional>true</optional>
-	</dependency>
-	<dependency>
-	<groupId>org.jenkins-ci.plugins</groupId>
-	<artifactId>git</artifactId>
-	<version>2.0</version>
-	<exclusions>
-		<exclusion>
-		<groupId>org.slf4j</groupId>
-		<artifactId>slf4j-jdk14</artifactId>
-		</exclusion>
-	</exclusions>
-	<optional>true</optional>
-	</dependency>
-	<dependency>
-	<groupId>org.jvnet.hudson.plugins</groupId>
-	<artifactId>perforce</artifactId>
-	<version>1.3.7</version>
-	<optional>true</optional>
-	</dependency>
-	<dependency>
-	<groupId>org.jenkins-ci.plugins</groupId>
-	<artifactId>ivy</artifactId>
-	<version>1.17</version>
-	<optional>true</optional>
-	</dependency>
-	<dependency>
-	<groupId>org.jenkins-ci.plugins</groupId>
-	<artifactId>ant</artifactId>
-	<version>1.2</version>
-	<optional>true</optional>
-	</dependency>
-	<dependency>
-	<groupId>org.jenkins-ci.plugins</groupId>
-	<artifactId>gradle</artifactId>
-	<version>1.15</version>
-	<optional>true</optional>
-	</dependency>
-	<dependency>
-	<groupId>org.jenkins-ci.plugins</groupId>
-	<artifactId>flexible-publish</artifactId>
-	<version>0.12</version>
-	<optional>true</optional>
-	</dependency>
-	<!-- usage of jenkins customized xstream is a must for the integration tests -->
-	<dependency>
-	<groupId>org.jvnet.hudson</groupId>
-	<artifactId>xstream</artifactId>
-	<version>1.3.1-hudson-8</version>
-	<scope>provided</scope>
-	</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>maven-plugin</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>subversion</artifactId>
+            <version>2.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jdk14</artifactId>
+                </exclusion>
+            </exclusions>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.hudson.plugins</groupId>
+            <artifactId>perforce</artifactId>
+            <version>1.3.7</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>ivy</artifactId>
+            <version>1.17</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.2</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>gradle</artifactId>
+            <version>1.15</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>flexible-publish</artifactId>
+            <version>0.12</version>
+            <optional>true</optional>
+        </dependency>
+        <!-- usage of jenkins customized xstream is a must for the integration tests -->
+        <dependency>
+            <groupId>org.jvnet.hudson</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.3.1-hudson-8</version>
+            <scope>provided</scope>
+        </dependency>
 
-	<dependency>
-	<groupId>org.jfrog.buildinfo</groupId>
-	<artifactId>build-info-api</artifactId>
-	<version>${buildinfo.version}</version>
-	<exclusions>
-		<exclusion>
-		<groupId>com.thoughtworks.xstream</groupId>
-		<artifactId>xstream</artifactId>
-		</exclusion>
-	</exclusions>
-	</dependency>
-	<dependency>
-	<groupId>org.jfrog.buildinfo</groupId>
-	<artifactId>build-info-client</artifactId>
-	<version>${buildinfo.version}</version>
-	<exclusions>
-		<exclusion>
-		<groupId>com.thoughtworks.xstream</groupId>
-		<artifactId>xstream</artifactId>
-		</exclusion>
-	</exclusions>
-	</dependency>
-	<dependency>
-	<groupId>org.jfrog.buildinfo</groupId>
-	<artifactId>build-info-extractor</artifactId>
-	<version>${buildinfo.version}</version>
-	<exclusions>
-		<exclusion>
-		<groupId>com.thoughtworks.xstream</groupId>
-		<artifactId>xstream</artifactId>
-		</exclusion>
-	</exclusions>
-	</dependency>
-	<dependency>
-	<groupId>org.jfrog.buildinfo</groupId>
-	<artifactId>build-info-vcs</artifactId>
-	<version>${buildinfo.version}</version>
-	<exclusions>
-		<exclusion>
-		<groupId>com.thoughtworks.xstream</groupId>
-		<artifactId>xstream</artifactId>
-		</exclusion>
-	</exclusions>
-	</dependency>
-	<dependency>
-	<!--
-		ZStream is declared final in 1.0.7, which is what build-info-vcs pulls in.
-		This causes a conflict with jzlib-1.1.2 that newer Jenkins uses.
-		If we didn't put too many classes into plexus.core, this would have been a non-issue.
-		See JENKINS-18401
-	-->
-	<groupId>com.jcraft</groupId>
-	<artifactId>jzlib</artifactId>
-	<version>1.1.2</version>
-	</dependency>
+        <dependency>
+            <groupId>org.jfrog.buildinfo</groupId>
+            <artifactId>build-info-api</artifactId>
+            <version>${buildinfo.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.thoughtworks.xstream</groupId>
+                    <artifactId>xstream</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jfrog.buildinfo</groupId>
+            <artifactId>build-info-client</artifactId>
+            <version>${buildinfo.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.thoughtworks.xstream</groupId>
+                    <artifactId>xstream</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jfrog.buildinfo</groupId>
+            <artifactId>build-info-extractor</artifactId>
+            <version>${buildinfo.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.thoughtworks.xstream</groupId>
+                    <artifactId>xstream</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jfrog.buildinfo</groupId>
+            <artifactId>build-info-vcs</artifactId>
+            <version>${buildinfo.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.thoughtworks.xstream</groupId>
+                    <artifactId>xstream</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <!--
+                ZStream is declared final in 1.0.7, which is what build-info-vcs pulls in.
+                This causes a conflict with jzlib-1.1.2 that newer Jenkins uses.
+                If we didn't put too many classes into plexus.core, this would have been a non-issue.
+                See JENKINS-18401
+             -->
+            <groupId>com.jcraft</groupId>
+            <artifactId>jzlib</artifactId>
+            <version>1.1.2</version>
+        </dependency>
 
-	<dependency>
-	<groupId>org.jfrog.buildinfo</groupId>
-	<artifactId>build-info-extractor-ivy</artifactId>
-	<version>${buildinfo.ivy.version}</version>
-	<exclusions>
-		<exclusion>
-		<groupId>org.apache.ant</groupId>
-		<artifactId>ant</artifactId>
-		</exclusion>
-		<exclusion>
-		<artifactId>groovy-all</artifactId>
-		<groupId>org.codehaus.groovy</groupId>
-		</exclusion>
-	</exclusions>
-	</dependency>
-	<dependency>
-	<groupId>org.jfrog.buildinfo</groupId>
-	<artifactId>build-info-extractor-maven3</artifactId>
-	<version>${buildinfo.maven3.version}</version>
-	</dependency>
-	<dependency>
-	<groupId>org.jfrog.buildinfo</groupId>
-	<artifactId>build-info-extractor-gradle</artifactId>
-	<version>${buildinfo.gradle.version}</version>
-	<exclusions>
-		<exclusion>
-		<groupId>org.apache.ant</groupId>
-		<artifactId>ant</artifactId>
-		</exclusion>
-		<exclusion>
-		<artifactId>groovy-all</artifactId>
-		<groupId>org.codehaus.groovy</groupId>
-		</exclusion>
-		<exclusion>
-		<groupId>org.codehaus.groovy</groupId>
-		<artifactId>groovy-all-minimal</artifactId>
-		</exclusion>
-		<exclusion>
-		<artifactId>gmaven-runtime-1.6</artifactId>
-		<groupId>org.codehaus.groovy.maven.runtime</groupId>
-		</exclusion>
-		<exclusion>
-		<groupId>org.gradle</groupId>
-		<artifactId>gradle-core</artifactId>
-		</exclusion>
-		<exclusion>
-		<groupId>org.gradle</groupId>
-		<artifactId>gradle-plugins</artifactId>
-		</exclusion>
-		<exclusion>
-		<groupId>com.tonicsystems.jarjar</groupId>
-		<artifactId>jarjar-plugin</artifactId>
-		</exclusion>
-	</exclusions>
-	</dependency>
-	<dependency>
-	<groupId>commons-lang</groupId>
-	<artifactId>commons-lang</artifactId>
-	<version>2.4</version>
-	</dependency>
-	<dependency>
-	<groupId>commons-codec</groupId>
-	<artifactId>commons-codec</artifactId>
-	<version>1.4</version>
-	</dependency>
-	<dependency>
-	<groupId>commons-io</groupId>
-	<artifactId>commons-io</artifactId>
-	<version>2.0.1</version>
-	</dependency>
-	<dependency>
-	<groupId>com.google.guava</groupId>
-	<artifactId>guava</artifactId>
-	<version>r08</version>
-	</dependency>
-	<dependency>
-	<groupId>org.codehaus.jackson</groupId>
-	<artifactId>jackson-mapper-asl</artifactId>
-	<version>1.5.1</version>
-	</dependency>
-	<dependency>
-	<groupId>org.jdom</groupId>
-	<artifactId>jdom</artifactId>
-	<version>1.1</version>
-	</dependency>
-	<dependency>
-	<groupId>org.apache.ivy</groupId>
-	<artifactId>ivy</artifactId>
-	<version>2.2.0</version>
-	</dependency>
-	<dependency>
-	<groupId>org.jenkins-ci.plugins</groupId>
-	<artifactId>jira</artifactId>
-	<version>1.29</version>
-	<optional>true</optional>
-	</dependency>
-	<dependency>
-	<groupId>org.jenkins-ci.plugins</groupId>
-	<artifactId>jenkins-multijob-plugin</artifactId>
-	<version>1.13</version>
-	<optional>true</optional>
-	</dependency>
-	<dependency>
-	<groupId>junit</groupId>
-	<artifactId>junit</artifactId>
-	<version>4.8.2</version>
-	<scope>test</scope>
-	</dependency>
-</dependencies>
+        <dependency>
+            <groupId>org.jfrog.buildinfo</groupId>
+            <artifactId>build-info-extractor-ivy</artifactId>
+            <version>${buildinfo.ivy.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>groovy-all</artifactId>
+                    <groupId>org.codehaus.groovy</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jfrog.buildinfo</groupId>
+            <artifactId>build-info-extractor-maven3</artifactId>
+            <version>${buildinfo.maven3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jfrog.buildinfo</groupId>
+            <artifactId>build-info-extractor-gradle</artifactId>
+            <version>${buildinfo.gradle.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>groovy-all</artifactId>
+                    <groupId>org.codehaus.groovy</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all-minimal</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>gmaven-runtime-1.6</artifactId>
+                    <groupId>org.codehaus.groovy.maven.runtime</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.gradle</groupId>
+                    <artifactId>gradle-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.gradle</groupId>
+                    <artifactId>gradle-plugins</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.tonicsystems.jarjar</groupId>
+                    <artifactId>jarjar-plugin</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>r08</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jira</artifactId>
+            <version>1.29</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jenkins-multijob-plugin</artifactId>
+            <version>1.13</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-<build>
-	<plugins>
-	<plugin>
-		<artifactId>maven-release-plugin</artifactId>
-		<configuration>
-		<goals>deploy</goals>
-		</configuration>
-	</plugin>
-	<plugin>
-		<groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-surefire-plugin</artifactId>
-		<version>2.8.1</version>
-		<configuration>
-		<excludes>
-			<exclude>**/InjectedTest.java</exclude>
-			<exclude>**/*ITest.java</exclude>
-		</excludes>
-		</configuration>
-	</plugin>
-	<plugin>
-		<groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-failsafe-plugin</artifactId>
-		<version>2.8.1</version>
-		<configuration>
-		<skipITs>true</skipITs>
-		<includes>
-			<include>**/*ITest.java</include>
-		</includes>
-		</configuration>
-		<executions>
-		<execution>
-			<id>integration-test</id>
-			<goals>
-			<goal>integration-test</goal>
-			</goals>
-		</execution>
-		<execution>
-			<id>verify</id>
-			<goals>
-			<goal>verify</goal>
-			</goals>
-		</execution>
-		</executions>
-	</plugin>
-	<plugin>
-		<groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-enforcer-plugin</artifactId>
-		<version>1.0</version>
-		<executions>
-		<execution>
-			<goals>
-			<goal>enforce</goal>
-			</goals>
-			<configuration>
-			<rules>
-				<bannedDependencies>
-				<excludes>
-					<!-- HAP-211 -->
-					<exclude>com.thoughtworks.xstream:xstream</exclude>
-					<exclude>org.slf4j:slf4j-jdk14:*:jar:compile</exclude>
-				</excludes>
-				</bannedDependencies>
-			</rules>
-			<fail>true</fail>
-			</configuration>
-		</execution>
-		</executions>
-	</plugin>
-	<plugin>
-		<groupId>org.zeroturnaround</groupId>
-		<artifactId>jrebel-maven-plugin</artifactId>
-		<version>1.1.1</version>
-		<configuration>
-		<packaging>jar</packaging>
-		</configuration>
-		<executions>
-		<execution>
-			<id>generate-rebel-xml</id>
-			<phase>process-resources</phase>
-			<goals>
-			<goal>generate</goal>
-			</goals>
-		</execution>
-		</executions>
-	</plugin>
-	</plugins>
-</build>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.8.1</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/InjectedTest.java</exclude>
+                        <exclude>**/*ITest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.8.1</version>
+                <configuration>
+                    <skipITs>true</skipITs>
+                    <includes>
+                        <include>**/*ITest.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- HAP-211 -->
+                                        <exclude>com.thoughtworks.xstream:xstream</exclude>
+                                        <exclude>org.slf4j:slf4j-jdk14:*:jar:compile</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.zeroturnaround</groupId>
+                <artifactId>jrebel-maven-plugin</artifactId>
+                <version>1.1.1</version>
+                <configuration>
+                    <packaging>jar</packaging>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-rebel-xml</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
-<scm>
-	<connection>scm:git:git://github.com/jenkinsci/artifactory-plugin.git</connection>
-	<developerConnection>scm:git:git@github.com:jenkinsci/artifactory-plugin.git</developerConnection>
-	<url>https://github.com/jenkinsci/artifactory-plugin</url>
-</scm>
+    <scm>
+        <connection>scm:git:git://github.com/jenkinsci/artifactory-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/artifactory-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/artifactory-plugin</url>
+    </scm>
 
-<profiles>
-	<profile>
-	<id>itest</id>
-	<build>
-		<plugins>
-		<plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-failsafe-plugin</artifactId>
-			<version>2.8.1</version>
-			<configuration>
-			<skipITs>false</skipITs>
-			</configuration>
-		</plugin>
-		</plugins>
-	</build>
-	</profile>
-	<profile>
-	<id>maven-glassfish</id>
-	<repositories>
-		<repository>
-		<id>repo.jenkins-ci.org</id>
-		<url>http://repo.jenkins-ci.org/public/</url>
-		</repository>
-	</repositories>
+    <profiles>
+        <profile>
+            <id>itest</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.8.1</version>
+                        <configuration>
+                            <skipITs>false</skipITs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>maven-glassfish</id>
+            <repositories>
+                <repository>
+                    <id>repo.jenkins-ci.org</id>
+                    <url>http://repo.jenkins-ci.org/public/</url>
+                </repository>
+            </repositories>
 
-	<pluginRepositories>
-		<pluginRepository>
-		<id>repo.jenkins-ci.org</id>
-		<url>http://repo.jenkins-ci.org/public/</url>
-		</pluginRepository>
-	</pluginRepositories>
-	</profile>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>repo.jenkins-ci.org</id>
+                    <url>http://repo.jenkins-ci.org/public/</url>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
 
-	<profile>
-	<id>jfrog</id>
-	<repositories>
-		<repository>
-		<id>central</id>
-		<name>jfrog-apps-dist</name>
-		<url>http://repo.jfrog.org/artifactory/libs-releases</url>
-		<snapshots>
-			<enabled>false</enabled>
-		</snapshots>
-		</repository>
-		<repository>
-		<id>snapshots</id>
-		<name>jfrog-apps-snapshots</name>
-		<url>http://repo.jfrog.org/artifactory/libs-snapshots</url>
-		<snapshots>
-			<enabled>true</enabled>
-		</snapshots>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-		<id>central</id>
-		<name>jfrog-plugins-dist</name>
-		<url>http://repo.jfrog.org/artifactory/plugins-releases</url>
-		<snapshots>
-			<enabled>false</enabled>
-		</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-		<id>snapshots</id>
-		<name>jfrog-plugins-snapshots</name>
-		<url>http://repo.jfrog.org/artifactory/plugins-snapshots</url>
-		<snapshots>
-			<enabled>true</enabled>
-		</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
-	</profile>
-</profiles>
+        <profile>
+            <id>jfrog</id>
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <name>jfrog-apps-dist</name>
+                    <url>http://repo.jfrog.org/artifactory/libs-releases</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>snapshots</id>
+                    <name>jfrog-apps-snapshots</name>
+                    <url>http://repo.jfrog.org/artifactory/libs-snapshots</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>central</id>
+                    <name>jfrog-plugins-dist</name>
+                    <url>http://repo.jfrog.org/artifactory/plugins-releases</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+                <pluginRepository>
+                    <id>snapshots</id>
+                    <name>jfrog-plugins-snapshots</name>
+                    <url>http://repo.jfrog.org/artifactory/plugins-snapshots</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
 
-<distributionManagement>
-	<repository>
-	<id>maven.jenkins-ci.org</id>
-	<url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-	</repository>
-</distributionManagement>
+    <distributionManagement>
+        <repository>
+            <id>maven.jenkins-ci.org</id>
+            <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,472 +1,474 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2011 JFrog Ltd.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  ~test
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>1.521</version>
-    </parent>
+~ Copyright (C) 2011 JFrog Ltd.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+~test
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<modelVersion>4.0.0</modelVersion>
+<parent>
+	<groupId>org.jenkins-ci.plugins</groupId>
+	<artifactId>plugin</artifactId>
+<!-- 	<version>1.521</version> -->
+	<version>1.532</version>
+	<!-- <version>1.615</version> -->
+</parent>
 
-    <artifactId>artifactory</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
-    <packaging>hpi</packaging>
-    <name>Jenkins Artifactory Plugin</name>
-    <description>Integrates Artifactory to Jenkins</description>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Artifactory+Plugin</url>
+<artifactId>artifactory</artifactId>
+<version>2.3.1-SNAPSHOT</version>
+<packaging>hpi</packaging>
+<name>Jenkins Artifactory Plugin</name>
+<description>Integrates Artifactory to Jenkins</description>
+<url>http://wiki.jenkins-ci.org/display/JENKINS/Artifactory+Plugin</url>
 
-    <properties>
-        <buildinfo.version>2.5.0</buildinfo.version>
-        <buildinfo.maven3.version>2.5.0</buildinfo.maven3.version>
-        <buildinfo.gradle.version>3.1.0</buildinfo.gradle.version>
-        <buildinfo.ivy.version>2.5.0</buildinfo.ivy.version>
-        <maven-release-plugin.version>2.2</maven-release-plugin.version>
-    </properties>
+<properties>
+	<buildinfo.version>2.5.0</buildinfo.version>
+	<buildinfo.maven3.version>2.5.0</buildinfo.maven3.version>
+	<buildinfo.gradle.version>3.1.0</buildinfo.gradle.version>
+	<buildinfo.ivy.version>2.5.0</buildinfo.ivy.version>
+	<maven-release-plugin.version>2.2</maven-release-plugin.version>
+</properties>
 
-    <developers>
-        <developer>
-            <id>yossis</id>
-            <name>Yossi Shaul</name>
-            <email>yossis@jfrog.org</email>
-            <roles>
-                <role>Lead Developer</role>
-            </roles>
-        </developer>
-    </developers>
+<developers>
+	<developer>
+	<id>yossis</id>
+	<name>Yossi Shaul</name>
+	<email>yossis@jfrog.org</email>
+	<roles>
+		<role>Lead Developer</role>
+	</roles>
+	</developer>
+</developers>
 
-    <organization>
-        <name>JFrog</name>
-        <url>http://www.jfrog.org</url>
-    </organization>
+<organization>
+	<name>JFrog</name>
+	<url>http://www.jfrog.org</url>
+</organization>
 
-    <issueManagement>
-        <system>jira</system>
-        <url>http://issues.jfrog.org/jira/browse/HAP</url>
-    </issueManagement>
+<issueManagement>
+	<system>jira</system>
+	<url>http://issues.jfrog.org/jira/browse/HAP</url>
+</issueManagement>
 
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
+<licenses>
+	<license>
+	<name>The Apache Software License, Version 2.0</name>
+	<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+	<distribution>repo</distribution>
+	</license>
+</licenses>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>maven-plugin</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>subversion</artifactId>
-            <version>2.0</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <version>2.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-jdk14</artifactId>
-                </exclusion>
-            </exclusions>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jvnet.hudson.plugins</groupId>
-            <artifactId>perforce</artifactId>
-            <version>1.3.7</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>ivy</artifactId>
-            <version>1.17</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>ant</artifactId>
-            <version>1.2</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>gradle</artifactId>
-            <version>1.15</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>flexible-publish</artifactId>
-            <version>0.12</version>
-            <optional>true</optional>
-        </dependency>
-        <!-- usage of jenkins customized xstream is a must for the integration tests -->
-        <dependency>
-            <groupId>org.jvnet.hudson</groupId>
-            <artifactId>xstream</artifactId>
-            <version>1.3.1-hudson-8</version>
-            <scope>provided</scope>
-        </dependency>
+<dependencies>
+	<dependency>
+	<groupId>org.jenkins-ci.main</groupId>
+	<artifactId>maven-plugin</artifactId>
+	<version>${project.parent.version}</version>
+	<optional>true</optional>
+	</dependency>
+	<dependency>
+	<groupId>org.jenkins-ci.plugins</groupId>
+	<artifactId>subversion</artifactId>
+	<version>2.0</version>
+	<optional>true</optional>
+	</dependency>
+	<dependency>
+	<groupId>org.jenkins-ci.plugins</groupId>
+	<artifactId>git</artifactId>
+	<version>2.0</version>
+	<exclusions>
+		<exclusion>
+		<groupId>org.slf4j</groupId>
+		<artifactId>slf4j-jdk14</artifactId>
+		</exclusion>
+	</exclusions>
+	<optional>true</optional>
+	</dependency>
+	<dependency>
+	<groupId>org.jvnet.hudson.plugins</groupId>
+	<artifactId>perforce</artifactId>
+	<version>1.3.7</version>
+	<optional>true</optional>
+	</dependency>
+	<dependency>
+	<groupId>org.jenkins-ci.plugins</groupId>
+	<artifactId>ivy</artifactId>
+	<version>1.17</version>
+	<optional>true</optional>
+	</dependency>
+	<dependency>
+	<groupId>org.jenkins-ci.plugins</groupId>
+	<artifactId>ant</artifactId>
+	<version>1.2</version>
+	<optional>true</optional>
+	</dependency>
+	<dependency>
+	<groupId>org.jenkins-ci.plugins</groupId>
+	<artifactId>gradle</artifactId>
+	<version>1.15</version>
+	<optional>true</optional>
+	</dependency>
+	<dependency>
+	<groupId>org.jenkins-ci.plugins</groupId>
+	<artifactId>flexible-publish</artifactId>
+	<version>0.12</version>
+	<optional>true</optional>
+	</dependency>
+	<!-- usage of jenkins customized xstream is a must for the integration tests -->
+	<dependency>
+	<groupId>org.jvnet.hudson</groupId>
+	<artifactId>xstream</artifactId>
+	<version>1.3.1-hudson-8</version>
+	<scope>provided</scope>
+	</dependency>
 
-        <dependency>
-            <groupId>org.jfrog.buildinfo</groupId>
-            <artifactId>build-info-api</artifactId>
-            <version>${buildinfo.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.thoughtworks.xstream</groupId>
-                    <artifactId>xstream</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jfrog.buildinfo</groupId>
-            <artifactId>build-info-client</artifactId>
-            <version>${buildinfo.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.thoughtworks.xstream</groupId>
-                    <artifactId>xstream</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jfrog.buildinfo</groupId>
-            <artifactId>build-info-extractor</artifactId>
-            <version>${buildinfo.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.thoughtworks.xstream</groupId>
-                    <artifactId>xstream</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jfrog.buildinfo</groupId>
-            <artifactId>build-info-vcs</artifactId>
-            <version>${buildinfo.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.thoughtworks.xstream</groupId>
-                    <artifactId>xstream</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <!--
-                ZStream is declared final in 1.0.7, which is what build-info-vcs pulls in.
-                This causes a conflict with jzlib-1.1.2 that newer Jenkins uses.
-                If we didn't put too many classes into plexus.core, this would have been a non-issue.
-                See JENKINS-18401
-             -->
-            <groupId>com.jcraft</groupId>
-            <artifactId>jzlib</artifactId>
-            <version>1.1.2</version>
-        </dependency>
+	<dependency>
+	<groupId>org.jfrog.buildinfo</groupId>
+	<artifactId>build-info-api</artifactId>
+	<version>${buildinfo.version}</version>
+	<exclusions>
+		<exclusion>
+		<groupId>com.thoughtworks.xstream</groupId>
+		<artifactId>xstream</artifactId>
+		</exclusion>
+	</exclusions>
+	</dependency>
+	<dependency>
+	<groupId>org.jfrog.buildinfo</groupId>
+	<artifactId>build-info-client</artifactId>
+	<version>${buildinfo.version}</version>
+	<exclusions>
+		<exclusion>
+		<groupId>com.thoughtworks.xstream</groupId>
+		<artifactId>xstream</artifactId>
+		</exclusion>
+	</exclusions>
+	</dependency>
+	<dependency>
+	<groupId>org.jfrog.buildinfo</groupId>
+	<artifactId>build-info-extractor</artifactId>
+	<version>${buildinfo.version}</version>
+	<exclusions>
+		<exclusion>
+		<groupId>com.thoughtworks.xstream</groupId>
+		<artifactId>xstream</artifactId>
+		</exclusion>
+	</exclusions>
+	</dependency>
+	<dependency>
+	<groupId>org.jfrog.buildinfo</groupId>
+	<artifactId>build-info-vcs</artifactId>
+	<version>${buildinfo.version}</version>
+	<exclusions>
+		<exclusion>
+		<groupId>com.thoughtworks.xstream</groupId>
+		<artifactId>xstream</artifactId>
+		</exclusion>
+	</exclusions>
+	</dependency>
+	<dependency>
+	<!--
+		ZStream is declared final in 1.0.7, which is what build-info-vcs pulls in.
+		This causes a conflict with jzlib-1.1.2 that newer Jenkins uses.
+		If we didn't put too many classes into plexus.core, this would have been a non-issue.
+		See JENKINS-18401
+	-->
+	<groupId>com.jcraft</groupId>
+	<artifactId>jzlib</artifactId>
+	<version>1.1.2</version>
+	</dependency>
 
-        <dependency>
-            <groupId>org.jfrog.buildinfo</groupId>
-            <artifactId>build-info-extractor-ivy</artifactId>
-            <version>${buildinfo.ivy.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.ant</groupId>
-                    <artifactId>ant</artifactId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>groovy-all</artifactId>
-                    <groupId>org.codehaus.groovy</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jfrog.buildinfo</groupId>
-            <artifactId>build-info-extractor-maven3</artifactId>
-            <version>${buildinfo.maven3.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jfrog.buildinfo</groupId>
-            <artifactId>build-info-extractor-gradle</artifactId>
-            <version>${buildinfo.gradle.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.ant</groupId>
-                    <artifactId>ant</artifactId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>groovy-all</artifactId>
-                    <groupId>org.codehaus.groovy</groupId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy-all-minimal</artifactId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>gmaven-runtime-1.6</artifactId>
-                    <groupId>org.codehaus.groovy.maven.runtime</groupId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.gradle</groupId>
-                    <artifactId>gradle-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.gradle</groupId>
-                    <artifactId>gradle-plugins</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.tonicsystems.jarjar</groupId>
-                    <artifactId>jarjar-plugin</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.4</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.4</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>r08</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.5.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jdom</groupId>
-            <artifactId>jdom</artifactId>
-            <version>1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ivy</groupId>
-            <artifactId>ivy</artifactId>
-            <version>2.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jira</artifactId>
-            <version>1.29</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jenkins-multijob-plugin</artifactId>
-            <version>1.13</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.2</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+	<dependency>
+	<groupId>org.jfrog.buildinfo</groupId>
+	<artifactId>build-info-extractor-ivy</artifactId>
+	<version>${buildinfo.ivy.version}</version>
+	<exclusions>
+		<exclusion>
+		<groupId>org.apache.ant</groupId>
+		<artifactId>ant</artifactId>
+		</exclusion>
+		<exclusion>
+		<artifactId>groovy-all</artifactId>
+		<groupId>org.codehaus.groovy</groupId>
+		</exclusion>
+	</exclusions>
+	</dependency>
+	<dependency>
+	<groupId>org.jfrog.buildinfo</groupId>
+	<artifactId>build-info-extractor-maven3</artifactId>
+	<version>${buildinfo.maven3.version}</version>
+	</dependency>
+	<dependency>
+	<groupId>org.jfrog.buildinfo</groupId>
+	<artifactId>build-info-extractor-gradle</artifactId>
+	<version>${buildinfo.gradle.version}</version>
+	<exclusions>
+		<exclusion>
+		<groupId>org.apache.ant</groupId>
+		<artifactId>ant</artifactId>
+		</exclusion>
+		<exclusion>
+		<artifactId>groovy-all</artifactId>
+		<groupId>org.codehaus.groovy</groupId>
+		</exclusion>
+		<exclusion>
+		<groupId>org.codehaus.groovy</groupId>
+		<artifactId>groovy-all-minimal</artifactId>
+		</exclusion>
+		<exclusion>
+		<artifactId>gmaven-runtime-1.6</artifactId>
+		<groupId>org.codehaus.groovy.maven.runtime</groupId>
+		</exclusion>
+		<exclusion>
+		<groupId>org.gradle</groupId>
+		<artifactId>gradle-core</artifactId>
+		</exclusion>
+		<exclusion>
+		<groupId>org.gradle</groupId>
+		<artifactId>gradle-plugins</artifactId>
+		</exclusion>
+		<exclusion>
+		<groupId>com.tonicsystems.jarjar</groupId>
+		<artifactId>jarjar-plugin</artifactId>
+		</exclusion>
+	</exclusions>
+	</dependency>
+	<dependency>
+	<groupId>commons-lang</groupId>
+	<artifactId>commons-lang</artifactId>
+	<version>2.4</version>
+	</dependency>
+	<dependency>
+	<groupId>commons-codec</groupId>
+	<artifactId>commons-codec</artifactId>
+	<version>1.4</version>
+	</dependency>
+	<dependency>
+	<groupId>commons-io</groupId>
+	<artifactId>commons-io</artifactId>
+	<version>2.0.1</version>
+	</dependency>
+	<dependency>
+	<groupId>com.google.guava</groupId>
+	<artifactId>guava</artifactId>
+	<version>r08</version>
+	</dependency>
+	<dependency>
+	<groupId>org.codehaus.jackson</groupId>
+	<artifactId>jackson-mapper-asl</artifactId>
+	<version>1.5.1</version>
+	</dependency>
+	<dependency>
+	<groupId>org.jdom</groupId>
+	<artifactId>jdom</artifactId>
+	<version>1.1</version>
+	</dependency>
+	<dependency>
+	<groupId>org.apache.ivy</groupId>
+	<artifactId>ivy</artifactId>
+	<version>2.2.0</version>
+	</dependency>
+	<dependency>
+	<groupId>org.jenkins-ci.plugins</groupId>
+	<artifactId>jira</artifactId>
+	<version>1.29</version>
+	<optional>true</optional>
+	</dependency>
+	<dependency>
+	<groupId>org.jenkins-ci.plugins</groupId>
+	<artifactId>jenkins-multijob-plugin</artifactId>
+	<version>1.13</version>
+	<optional>true</optional>
+	</dependency>
+	<dependency>
+	<groupId>junit</groupId>
+	<artifactId>junit</artifactId>
+	<version>4.8.2</version>
+	<scope>test</scope>
+	</dependency>
+</dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <goals>deploy</goals>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.8.1</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/InjectedTest.java</exclude>
-                        <exclude>**/*ITest.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.8.1</version>
-                <configuration>
-                    <skipITs>true</skipITs>
-                    <includes>
-                        <include>**/*ITest.java</include>
-                    </includes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>integration-test</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>verify</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <bannedDependencies>
-                                    <excludes>
-                                        <!-- HAP-211 -->
-                                        <exclude>com.thoughtworks.xstream:xstream</exclude>
-                                        <exclude>org.slf4j:slf4j-jdk14:*:jar:compile</exclude>
-                                    </excludes>
-                                </bannedDependencies>
-                            </rules>
-                            <fail>true</fail>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.zeroturnaround</groupId>
-                <artifactId>jrebel-maven-plugin</artifactId>
-                <version>1.1.1</version>
-                <configuration>
-                    <packaging>jar</packaging>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>generate-rebel-xml</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+<build>
+	<plugins>
+	<plugin>
+		<artifactId>maven-release-plugin</artifactId>
+		<configuration>
+		<goals>deploy</goals>
+		</configuration>
+	</plugin>
+	<plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-surefire-plugin</artifactId>
+		<version>2.8.1</version>
+		<configuration>
+		<excludes>
+			<exclude>**/InjectedTest.java</exclude>
+			<exclude>**/*ITest.java</exclude>
+		</excludes>
+		</configuration>
+	</plugin>
+	<plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-failsafe-plugin</artifactId>
+		<version>2.8.1</version>
+		<configuration>
+		<skipITs>true</skipITs>
+		<includes>
+			<include>**/*ITest.java</include>
+		</includes>
+		</configuration>
+		<executions>
+		<execution>
+			<id>integration-test</id>
+			<goals>
+			<goal>integration-test</goal>
+			</goals>
+		</execution>
+		<execution>
+			<id>verify</id>
+			<goals>
+			<goal>verify</goal>
+			</goals>
+		</execution>
+		</executions>
+	</plugin>
+	<plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-enforcer-plugin</artifactId>
+		<version>1.0</version>
+		<executions>
+		<execution>
+			<goals>
+			<goal>enforce</goal>
+			</goals>
+			<configuration>
+			<rules>
+				<bannedDependencies>
+				<excludes>
+					<!-- HAP-211 -->
+					<exclude>com.thoughtworks.xstream:xstream</exclude>
+					<exclude>org.slf4j:slf4j-jdk14:*:jar:compile</exclude>
+				</excludes>
+				</bannedDependencies>
+			</rules>
+			<fail>true</fail>
+			</configuration>
+		</execution>
+		</executions>
+	</plugin>
+	<plugin>
+		<groupId>org.zeroturnaround</groupId>
+		<artifactId>jrebel-maven-plugin</artifactId>
+		<version>1.1.1</version>
+		<configuration>
+		<packaging>jar</packaging>
+		</configuration>
+		<executions>
+		<execution>
+			<id>generate-rebel-xml</id>
+			<phase>process-resources</phase>
+			<goals>
+			<goal>generate</goal>
+			</goals>
+		</execution>
+		</executions>
+	</plugin>
+	</plugins>
+</build>
 
-    <scm>
-        <connection>scm:git:git://github.com/jenkinsci/artifactory-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/artifactory-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/artifactory-plugin</url>
-    </scm>
+<scm>
+	<connection>scm:git:git://github.com/jenkinsci/artifactory-plugin.git</connection>
+	<developerConnection>scm:git:git@github.com:jenkinsci/artifactory-plugin.git</developerConnection>
+	<url>https://github.com/jenkinsci/artifactory-plugin</url>
+</scm>
 
-    <profiles>
-        <profile>
-            <id>itest</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.8.1</version>
-                        <configuration>
-                            <skipITs>false</skipITs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>maven-glassfish</id>
-            <repositories>
-                <repository>
-                    <id>repo.jenkins-ci.org</id>
-                    <url>http://repo.jenkins-ci.org/public/</url>
-                </repository>
-            </repositories>
+<profiles>
+	<profile>
+	<id>itest</id>
+	<build>
+		<plugins>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-failsafe-plugin</artifactId>
+			<version>2.8.1</version>
+			<configuration>
+			<skipITs>false</skipITs>
+			</configuration>
+		</plugin>
+		</plugins>
+	</build>
+	</profile>
+	<profile>
+	<id>maven-glassfish</id>
+	<repositories>
+		<repository>
+		<id>repo.jenkins-ci.org</id>
+		<url>http://repo.jenkins-ci.org/public/</url>
+		</repository>
+	</repositories>
 
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>repo.jenkins-ci.org</id>
-                    <url>http://repo.jenkins-ci.org/public/</url>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
+	<pluginRepositories>
+		<pluginRepository>
+		<id>repo.jenkins-ci.org</id>
+		<url>http://repo.jenkins-ci.org/public/</url>
+		</pluginRepository>
+	</pluginRepositories>
+	</profile>
 
-        <profile>
-            <id>jfrog</id>
-            <repositories>
-                <repository>
-                    <id>central</id>
-                    <name>jfrog-apps-dist</name>
-                    <url>http://repo.jfrog.org/artifactory/libs-releases</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-                <repository>
-                    <id>snapshots</id>
-                    <name>jfrog-apps-snapshots</name>
-                    <url>http://repo.jfrog.org/artifactory/libs-snapshots</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>central</id>
-                    <name>jfrog-plugins-dist</name>
-                    <url>http://repo.jfrog.org/artifactory/plugins-releases</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-                <pluginRepository>
-                    <id>snapshots</id>
-                    <name>jfrog-plugins-snapshots</name>
-                    <url>http://repo.jfrog.org/artifactory/plugins-snapshots</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
-    </profiles>
+	<profile>
+	<id>jfrog</id>
+	<repositories>
+		<repository>
+		<id>central</id>
+		<name>jfrog-apps-dist</name>
+		<url>http://repo.jfrog.org/artifactory/libs-releases</url>
+		<snapshots>
+			<enabled>false</enabled>
+		</snapshots>
+		</repository>
+		<repository>
+		<id>snapshots</id>
+		<name>jfrog-apps-snapshots</name>
+		<url>http://repo.jfrog.org/artifactory/libs-snapshots</url>
+		<snapshots>
+			<enabled>true</enabled>
+		</snapshots>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+		<id>central</id>
+		<name>jfrog-plugins-dist</name>
+		<url>http://repo.jfrog.org/artifactory/plugins-releases</url>
+		<snapshots>
+			<enabled>false</enabled>
+		</snapshots>
+		</pluginRepository>
+		<pluginRepository>
+		<id>snapshots</id>
+		<name>jfrog-plugins-snapshots</name>
+		<url>http://repo.jfrog.org/artifactory/plugins-snapshots</url>
+		<snapshots>
+			<enabled>true</enabled>
+		</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+	</profile>
+</profiles>
 
-    <distributionManagement>
-        <repository>
-            <id>maven.jenkins-ci.org</id>
-            <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-        </repository>
-    </distributionManagement>
+<distributionManagement>
+	<repository>
+	<id>maven.jenkins-ci.org</id>
+	<url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
+	</repository>
+</distributionManagement>
 </project>

--- a/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
@@ -41,387 +41,395 @@ import java.util.List;
  * @author Shay Yaakov
  */
 public class ArtifactoryGenericConfigurator extends BuildWrapper implements DeployerOverrider,
-        BuildInfoAwareConfigurator, MultiConfigurationAware {
-
-    private final ServerDetails details;
-    private final Credentials overridingDeployerCredentials;
-    private final String deployPattern;
-    private final String resolvePattern;
-    private final String matrixParams;
-
-    private final boolean deployBuildInfo;
-    /**
-     * Include environment variables in the generated build info
-     */
-    private final boolean includeEnvVars;
-    private final IncludesExcludes envVarsPatterns;
-    private final boolean discardOldBuilds;
-    private final boolean discardBuildArtifacts;
-    private transient List<Dependency> publishedDependencies;
-    private transient List<BuildDependency> buildDependencies;
-    private String artifactoryCombinationFilter;
-    private boolean multiConfProject;
-    /**
-     * Don't need it anymore since now the slave uses it's own client to deploy the artifacts
-     */
-    @Deprecated
-    private transient String keepArchivedArtifacts;
-
-    @DataBoundConstructor
-    public ArtifactoryGenericConfigurator(ServerDetails details, Credentials overridingDeployerCredentials,
-                                          String deployPattern, String resolvePattern, String matrixParams,
-                                          boolean deployBuildInfo,
-                                          boolean includeEnvVars, IncludesExcludes envVarsPatterns,
-                                          boolean discardOldBuilds,
-                                          boolean discardBuildArtifacts,
-                                          boolean multiConfProject,
-                                          String artifactoryCombinationFilter) {
-        this.details = details;
-        this.overridingDeployerCredentials = overridingDeployerCredentials;
-        this.deployPattern = deployPattern;
-        this.resolvePattern = resolvePattern;
-        this.matrixParams = matrixParams;
-        this.deployBuildInfo = deployBuildInfo;
-        this.includeEnvVars = includeEnvVars;
-        this.envVarsPatterns = envVarsPatterns;
-        this.discardOldBuilds = discardOldBuilds;
-        this.discardBuildArtifacts = discardBuildArtifacts;
-        this.multiConfProject = multiConfProject;
-        this.artifactoryCombinationFilter = artifactoryCombinationFilter;
-    }
-
-    public String getArtifactoryName() {
-        return details != null ? details.artifactoryName : null;
-    }
-
-    public String getArtifactoryUrl() {
-        return details != null ? details.getArtifactoryUrl() : null;
-    }
-
-    public boolean isOverridingDefaultDeployer() {
-        return getOverridingDeployerCredentials() != null;
-    }
-
-    public String getRepositoryKey() {
-        return details.getDeployReleaseRepository().getRepoKey();
-    }
-
-    public ServerDetails getDetails() {
-        return details;
-    }
-
-    public Credentials getOverridingDeployerCredentials() {
-        return overridingDeployerCredentials;
-    }
-
-    public String getDeployPattern() {
-        return deployPattern;
-    }
-
-    public String getResolvePattern() {
-        return resolvePattern;
-    }
-
-    public String getMatrixParams() {
-        return matrixParams;
-    }
-
-    public boolean isDeployBuildInfo() {
-        return deployBuildInfo;
-    }
-
-    public boolean isIncludeEnvVars() {
-        return includeEnvVars;
-    }
-
-    public IncludesExcludes getEnvVarsPatterns() {
-        return envVarsPatterns;
-    }
-
-    public boolean isRunChecks() {
-        // There is no use of license checks in a generic build
-        return false;
-    }
-
-    public String getViolationRecipients() {
-        return null;
-    }
-
-    public boolean isIncludePublishArtifacts() {
-        return false;
-    }
-
-    public String getScopes() {
-        return null;
-    }
-
-    public boolean isLicenseAutoDiscovery() {
-        return false;
-    }
-
-    public boolean isDiscardOldBuilds() {
-        return discardOldBuilds;
-    }
-
-    public boolean isDiscardBuildArtifacts() {
-        return discardBuildArtifacts;
-    }
-
-    public boolean isEnableIssueTrackerIntegration() {
-        return false;
-    }
-
-    public boolean isAggregateBuildIssues() {
-        return false;
-    }
-
-    public String getAggregationBuildStatus() {
-        return null;
-    }
-
-    public boolean isBlackDuckRunChecks() {
-        return false;
-    }
-
-    public String getBlackDuckAppName() {
-        return null;
-    }
-
-    public String getBlackDuckAppVersion() {
-        return null;
-    }
-
-    public String getBlackDuckReportRecipients() {
-        return null;
-    }
-
-    public String getBlackDuckScopes() {
-        return null;
-    }
-
-    public boolean isBlackDuckIncludePublishedArtifacts() {
-        return false;
-    }
-
-    public boolean isAutoCreateMissingComponentRequests() {
-        return false;
-    }
-
-    public boolean isAutoDiscardStaleComponentRequests() {
-        return false;
-    }
-
-    public String getArtifactoryCombinationFilter() {
-        return artifactoryCombinationFilter;
-    }
-
-    public boolean isMultiConfProject() {
-        return multiConfProject;
-    }
-
-    public ArtifactoryServer getArtifactoryServer() {
-        return RepositoriesUtils.getArtifactoryServer(getArtifactoryName(), getDescriptor().getArtifactoryServers());
-    }
-
-    public List<Repository> getReleaseRepositoryList() {
-        return RepositoriesUtils.collectRepositories(getDescriptor().releaseRepositories, details.getDeploySnapshotRepository().getKeyFromSelect());
-    }
-
-    @Override
-    public Collection<? extends Action> getProjectActions(AbstractProject project) {
-        return ActionableHelper.getArtifactoryProjectAction(getArtifactoryUrl(), project);
-    }
-
-    @Override
-    public Environment setUp(final AbstractBuild build, Launcher launcher, BuildListener listener)
-            throws IOException, InterruptedException {
-        RepositoriesUtils.validateServerConfig(build, listener, getArtifactoryServer(), getArtifactoryUrl());
-
-        final String artifactoryServerName = getArtifactoryName();
-        if (StringUtils.isBlank(artifactoryServerName)) {
-            return super.setUp(build, launcher, listener);
-        }
-
-        hudson.ProxyConfiguration proxy = Jenkins.getInstance().proxy;
-        ProxyConfiguration proxyConfiguration = null;
-        if (proxy != null) {
-            proxyConfiguration = new ProxyConfiguration();
-            proxyConfiguration.host = proxy.name;
-            proxyConfiguration.port = proxy.port;
-            proxyConfiguration.username = proxy.getUserName();
-            proxyConfiguration.password = proxy.getPassword();
-        }
-
-        ArtifactoryServer server = getArtifactoryServer();
-        Credentials preferredResolver = CredentialResolver.getPreferredResolver(null, ArtifactoryGenericConfigurator.this, server);
-        ArtifactoryDependenciesClient dependenciesClient = server.createArtifactoryDependenciesClient(
-                preferredResolver.getUsername(), preferredResolver.getPassword(), proxyConfiguration,
-                listener);
-        try {
-            GenericArtifactsResolver artifactsResolver = new GenericArtifactsResolver(build, listener,
-                    dependenciesClient, getResolvePattern());
-            publishedDependencies = artifactsResolver.retrievePublishedDependencies();
-            buildDependencies = artifactsResolver.retrieveBuildDependencies();
-
-            return createEnvironmentOnSuccessfulSetup();
-        } catch (Exception e) {
-            e.printStackTrace(listener.error(e.getMessage()));
-        } finally {
-            dependenciesClient.shutdown();
-        }
-
-        return null;
-    }
-
-    private Environment createEnvironmentOnSuccessfulSetup() {
-        return new Environment() {
-            @Override
-            public boolean tearDown(AbstractBuild build, BuildListener listener)
-                    throws IOException, InterruptedException {
-                Result result = build.getResult();
-                if (result != null && result.isWorseThan(Result.SUCCESS)) {
-                    return true;    // build failed. Don't publish
-                }
-
-                ArtifactoryServer server = getArtifactoryServer();
-                Credentials preferredDeployer = CredentialResolver.getPreferredDeployer(ArtifactoryGenericConfigurator.this, server);
-                ArtifactoryBuildInfoClient client = server.createArtifactoryClient(preferredDeployer.getUsername(),
-                        preferredDeployer.getPassword(), server.createProxyConfiguration(Jenkins.getInstance().proxy));
-                try {
-                    boolean isFiltered = false;
-                    if (isMultiConfProject(build)) {
-                        if (multiConfProject && StringUtils.isBlank(getArtifactoryCombinationFilter())) {
-                            String error = "The field \"Combination Matches\" is empty, but is defined as mandatory!";
-                            listener.getLogger().println(error);
-                            build.setResult(Result.FAILURE);
-                            throw new IllegalArgumentException(error);
-                        }
-                        isFiltered = MultiConfigurationUtils.isfiltrated(build, getArtifactoryCombinationFilter());
-                    }
-
-                    if (!isFiltered) {
-                        GenericArtifactsDeployer artifactsDeployer = new GenericArtifactsDeployer(build,
-                                ArtifactoryGenericConfigurator.this, listener, preferredDeployer);
-                        artifactsDeployer.deploy();
-
-                        List<Artifact> deployedArtifacts = artifactsDeployer.getDeployedArtifacts();
-                        if (deployBuildInfo) {
-                            new GenericBuildInfoDeployer(ArtifactoryGenericConfigurator.this, client, build,
-                                    listener, deployedArtifacts, buildDependencies, publishedDependencies).deploy();
-                            // add the result action (prefer always the same index)
-                            build.getActions().add(0, new BuildInfoResultAction(getArtifactoryUrl(), build));
-                            build.getActions().add(new UnifiedPromoteBuildAction<ArtifactoryGenericConfigurator>(build,
-                                    ArtifactoryGenericConfigurator.this));
-                            build.getActions().add(new BintrayPublishAction<ArtifactoryGenericConfigurator>(build,
-                                    ArtifactoryGenericConfigurator.this));
-                        }
-                    }
-
-                    return true;
-                } catch (Exception e) {
-                    e.printStackTrace(listener.error(e.getMessage()));
-                } finally {
-                    client.shutdown();
-                }
-
-                // failed
-                build.setResult(Result.FAILURE);
-                return true;
-            }
-        };
-    }
-
-    private boolean isMultiConfProject(AbstractBuild build) {
-        return (build.getProject().getClass().equals(MatrixConfiguration.class));
-    }
-
-    @Override
-    public DescriptorImpl getDescriptor() {
-        return (DescriptorImpl) super.getDescriptor();
-    }
-
-    @Extension(optional = true)
-    public static class DescriptorImpl extends BuildWrapperDescriptor {
-
-        private List<Repository> releaseRepositories;
-        private AbstractProject<?, ?> item;
-
-        public DescriptorImpl() {
-            super(ArtifactoryGenericConfigurator.class);
-            load();
-        }
-
-        @Override
-        public boolean isApplicable(AbstractProject<?, ?> item) {
-            this.item = item;
-            return item.getClass().isAssignableFrom(FreeStyleProject.class) ||
-                item.getClass().isAssignableFrom(MatrixProject.class) ||
-                    (Jenkins.getInstance().getPlugin(PluginsUtils.MULTIJOB_PLUGIN_ID) != null &&
-                        item.getClass().isAssignableFrom(MultiJobProject.class));
-        }
-
-        /**
-         * This method triggered from the client side by Ajax call.
-         * The Element that trig is the "Refresh Repositories" button.
-         *
-         * @param url                           the artifactory url
-         * @param credentialsUsername           override credentials user name
-         * @param credentialsPassword           override credentials password
-         * @param overridingDeployerCredentials user choose to override credentials
-         * @return {@link org.jfrog.hudson.util.RefreshServerResponse} object that represents the response of the repositories
-         */
-        @JavaScriptMethod
-        public RefreshServerResponse refreshFromArtifactory(String url, String credentialsUsername, String credentialsPassword, boolean overridingDeployerCredentials) {
-            RefreshServerResponse response = new RefreshServerResponse();
-            ArtifactoryServer artifactoryServer = RepositoriesUtils.getArtifactoryServer(url, RepositoriesUtils.getArtifactoryServers());
-
-            try {
-                List<String> releaseRepositoryKeysFirst = RepositoriesUtils.getLocalRepositories(url, credentialsUsername, credentialsPassword,
-                        overridingDeployerCredentials, artifactoryServer);
-
-                Collections.sort(releaseRepositoryKeysFirst);
-                releaseRepositories = RepositoriesUtils.createRepositoriesList(releaseRepositoryKeysFirst);
-                response.setRepositories(releaseRepositories);
-                response.setSuccess(true);
-
-                return response;
-            } catch (Exception e) {
-                e.printStackTrace();
-                response.setResponseMessage(e.getMessage());
-                response.setSuccess(false);
-            }
-
-            return response;
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "Generic-Artifactory Integration";
-        }
-
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-            req.bindParameters(this, "generic");
-            save();
-            return true;
-        }
-
-        public boolean isMultiConfProject() {
-            return (item.getClass().isAssignableFrom(MatrixProject.class));
-        }
-
-        public FormValidation doCheckArtifactoryCombinationFilter(@QueryParameter String value)
-                throws IOException, InterruptedException {
-            return FormValidations.validateArtifactoryCombinationFilter(value);
-        }
-
-        /**
-         * Returns the list of {@link org.jfrog.hudson.ArtifactoryServer} configured.
-         *
-         * @return can be empty but never null.
-         */
-        public List<ArtifactoryServer> getArtifactoryServers() {
-            return RepositoriesUtils.getArtifactoryServers();
-        }
-    }
+		BuildInfoAwareConfigurator, MultiConfigurationAware {
+
+	private final ServerDetails details;
+	private final Credentials overridingDeployerCredentials;
+	private final String deployPattern;
+	private final String resolvePattern;
+	private final String matrixParams;
+
+	private final boolean deployBuildInfo;
+	/**
+	 * Include environment variables in the generated build info
+	 */
+	private final boolean includeEnvVars;
+	private final IncludesExcludes envVarsPatterns;
+	private final boolean discardOldBuilds;
+	private final boolean discardBuildArtifacts;
+	private transient List<Dependency> publishedDependencies;
+	private transient List<BuildDependency> buildDependencies;
+	private String artifactoryCombinationFilter;
+	private boolean multiConfProject;
+	
+	private final boolean removeRelativePath;
+	/**
+	 * Don't need it anymore since now the slave uses it's own client to deploy the artifacts
+	 */
+	@Deprecated
+	private transient String keepArchivedArtifacts;
+
+	@DataBoundConstructor
+	public ArtifactoryGenericConfigurator(ServerDetails details, Credentials overridingDeployerCredentials,
+										  String deployPattern, String resolvePattern, String matrixParams,
+										  boolean deployBuildInfo,
+										  boolean includeEnvVars, IncludesExcludes envVarsPatterns,
+										  boolean discardOldBuilds,
+										  boolean discardBuildArtifacts,
+										  boolean multiConfProject,
+										  String artifactoryCombinationFilter,
+										  boolean removeRelativePath) {
+		this.details = details;
+		this.overridingDeployerCredentials = overridingDeployerCredentials;
+		this.deployPattern = deployPattern;
+		this.resolvePattern = resolvePattern;
+		this.matrixParams = matrixParams;
+		this.deployBuildInfo = deployBuildInfo;
+		this.includeEnvVars = includeEnvVars;
+		this.envVarsPatterns = envVarsPatterns;
+		this.discardOldBuilds = discardOldBuilds;
+		this.discardBuildArtifacts = discardBuildArtifacts;
+		this.multiConfProject = multiConfProject;
+		this.artifactoryCombinationFilter = artifactoryCombinationFilter;
+		this.removeRelativePath = removeRelativePath;
+	}
+
+	public String getArtifactoryName() {
+		return details != null ? details.artifactoryName : null;
+	}
+
+	public String getArtifactoryUrl() {
+		return details != null ? details.getArtifactoryUrl() : null;
+	}
+
+	public boolean isOverridingDefaultDeployer() {
+		return getOverridingDeployerCredentials() != null;
+	}
+
+	public String getRepositoryKey() {
+		return details.getDeployReleaseRepository().getRepoKey();
+	}
+
+	public ServerDetails getDetails() {
+		return details;
+	}
+
+	public Credentials getOverridingDeployerCredentials() {
+		return overridingDeployerCredentials;
+	}
+
+	public String getDeployPattern() {
+		return deployPattern;
+	}
+
+	public String getResolvePattern() {
+		return resolvePattern;
+	}
+
+	public String getMatrixParams() {
+		return matrixParams;
+	}
+
+	public boolean isDeployBuildInfo() {
+		return deployBuildInfo;
+	}
+
+	public boolean isIncludeEnvVars() {
+		return includeEnvVars;
+	}
+
+	public IncludesExcludes getEnvVarsPatterns() {
+		return envVarsPatterns;
+	}
+
+	public boolean isRunChecks() {
+		// There is no use of license checks in a generic build
+		return false;
+	}
+
+	public String getViolationRecipients() {
+		return null;
+	}
+
+	public boolean isIncludePublishArtifacts() {
+		return false;
+	}
+
+	public String getScopes() {
+		return null;
+	}
+
+	public boolean isLicenseAutoDiscovery() {
+		return false;
+	}
+
+	public boolean isDiscardOldBuilds() {
+		return discardOldBuilds;
+	}
+
+	public boolean isDiscardBuildArtifacts() {
+		return discardBuildArtifacts;
+	}
+
+	public boolean isEnableIssueTrackerIntegration() {
+		return false;
+	}
+
+	public boolean isAggregateBuildIssues() {
+		return false;
+	}
+
+	public String getAggregationBuildStatus() {
+		return null;
+	}
+
+	public boolean isBlackDuckRunChecks() {
+		return false;
+	}
+
+	public String getBlackDuckAppName() {
+		return null;
+	}
+
+	public String getBlackDuckAppVersion() {
+		return null;
+	}
+
+	public String getBlackDuckReportRecipients() {
+		return null;
+	}
+
+	public String getBlackDuckScopes() {
+		return null;
+	}
+
+	public boolean isBlackDuckIncludePublishedArtifacts() {
+		return false;
+	}
+
+	public boolean isAutoCreateMissingComponentRequests() {
+		return false;
+	}
+
+	public boolean isAutoDiscardStaleComponentRequests() {
+		return false;
+	}
+
+	public String getArtifactoryCombinationFilter() {
+		return artifactoryCombinationFilter;
+	}
+
+	public boolean isMultiConfProject() {
+		return multiConfProject;
+	}
+	
+	public boolean isRemoveRelativePath() {
+		return removeRelativePath;
+	}
+
+	public ArtifactoryServer getArtifactoryServer() {
+		return RepositoriesUtils.getArtifactoryServer(getArtifactoryName(), getDescriptor().getArtifactoryServers());
+	}
+
+	public List<Repository> getReleaseRepositoryList() {
+		return RepositoriesUtils.collectRepositories(getDescriptor().releaseRepositories, details.getDeploySnapshotRepository().getKeyFromSelect());
+	}
+
+	@Override
+	public Collection<? extends Action> getProjectActions(AbstractProject project) {
+		return ActionableHelper.getArtifactoryProjectAction(getArtifactoryUrl(), project);
+	}
+
+	@Override
+	public Environment setUp(final AbstractBuild build, Launcher launcher, BuildListener listener)
+			throws IOException, InterruptedException {
+		RepositoriesUtils.validateServerConfig(build, listener, getArtifactoryServer(), getArtifactoryUrl());
+
+		final String artifactoryServerName = getArtifactoryName();
+		if (StringUtils.isBlank(artifactoryServerName)) {
+			return super.setUp(build, launcher, listener);
+		}
+
+		hudson.ProxyConfiguration proxy = Jenkins.getInstance().proxy;
+		ProxyConfiguration proxyConfiguration = null;
+		if (proxy != null) {
+			proxyConfiguration = new ProxyConfiguration();
+			proxyConfiguration.host = proxy.name;
+			proxyConfiguration.port = proxy.port;
+			proxyConfiguration.username = proxy.getUserName();
+			proxyConfiguration.password = proxy.getPassword();
+		}
+
+		ArtifactoryServer server = getArtifactoryServer();
+		Credentials preferredResolver = CredentialResolver.getPreferredResolver(null, ArtifactoryGenericConfigurator.this, server);
+		ArtifactoryDependenciesClient dependenciesClient = server.createArtifactoryDependenciesClient(
+				preferredResolver.getUsername(), preferredResolver.getPassword(), proxyConfiguration,
+				listener);
+		try {
+			GenericArtifactsResolver artifactsResolver = new GenericArtifactsResolver(build, listener,
+					dependenciesClient, getResolvePattern());
+			publishedDependencies = artifactsResolver.retrievePublishedDependencies();
+			buildDependencies = artifactsResolver.retrieveBuildDependencies();
+
+			return createEnvironmentOnSuccessfulSetup();
+		} catch (Exception e) {
+			e.printStackTrace(listener.error(e.getMessage()));
+		} finally {
+			dependenciesClient.shutdown();
+		}
+
+		return null;
+	}
+
+	private Environment createEnvironmentOnSuccessfulSetup() {
+		return new Environment() {
+			@Override
+			public boolean tearDown(AbstractBuild build, BuildListener listener)
+					throws IOException, InterruptedException {
+				Result result = build.getResult();
+				if (result != null && result.isWorseThan(Result.SUCCESS)) {
+					return true;    // build failed. Don't publish
+				}
+
+				ArtifactoryServer server = getArtifactoryServer();
+				Credentials preferredDeployer = CredentialResolver.getPreferredDeployer(ArtifactoryGenericConfigurator.this, server);
+				ArtifactoryBuildInfoClient client = server.createArtifactoryClient(preferredDeployer.getUsername(),
+						preferredDeployer.getPassword(), server.createProxyConfiguration(Jenkins.getInstance().proxy));
+				try {
+					boolean isFiltered = false;
+					if (isMultiConfProject(build)) {
+						if (multiConfProject && StringUtils.isBlank(getArtifactoryCombinationFilter())) {
+							String error = "The field \"Combination Matches\" is empty, but is defined as mandatory!";
+							listener.getLogger().println(error);
+							build.setResult(Result.FAILURE);
+							throw new IllegalArgumentException(error);
+						}
+						isFiltered = MultiConfigurationUtils.isfiltrated(build, getArtifactoryCombinationFilter());
+					}
+
+					if (!isFiltered) {
+						GenericArtifactsDeployer artifactsDeployer = new GenericArtifactsDeployer(build,
+								ArtifactoryGenericConfigurator.this, listener, preferredDeployer);
+						artifactsDeployer.deploy();
+
+						List<Artifact> deployedArtifacts = artifactsDeployer.getDeployedArtifacts();
+						if (deployBuildInfo) {
+							new GenericBuildInfoDeployer(ArtifactoryGenericConfigurator.this, client, build,
+									listener, deployedArtifacts, buildDependencies, publishedDependencies).deploy();
+							// add the result action (prefer always the same index)
+							build.getActions().add(0, new BuildInfoResultAction(getArtifactoryUrl(), build));
+							build.getActions().add(new UnifiedPromoteBuildAction<ArtifactoryGenericConfigurator>(build,
+									ArtifactoryGenericConfigurator.this));
+							build.getActions().add(new BintrayPublishAction<ArtifactoryGenericConfigurator>(build,
+									ArtifactoryGenericConfigurator.this));
+						}
+					}
+
+					return true;
+				} catch (Exception e) {
+					e.printStackTrace(listener.error(e.getMessage()));
+				} finally {
+					client.shutdown();
+				}
+
+				// failed
+				build.setResult(Result.FAILURE);
+				return true;
+			}
+		};
+	}
+
+	private boolean isMultiConfProject(AbstractBuild build) {
+		return (build.getProject().getClass().equals(MatrixConfiguration.class));
+	}
+
+	@Override
+	public DescriptorImpl getDescriptor() {
+		return (DescriptorImpl) super.getDescriptor();
+	}
+
+	@Extension(optional = true)
+	public static class DescriptorImpl extends BuildWrapperDescriptor {
+
+		private List<Repository> releaseRepositories;
+		private AbstractProject<?, ?> item;
+
+		public DescriptorImpl() {
+			super(ArtifactoryGenericConfigurator.class);
+			load();
+		}
+
+		@Override
+		public boolean isApplicable(AbstractProject<?, ?> item) {
+			this.item = item;
+			return item.getClass().isAssignableFrom(FreeStyleProject.class) ||
+				item.getClass().isAssignableFrom(MatrixProject.class) ||
+					(Jenkins.getInstance().getPlugin(PluginsUtils.MULTIJOB_PLUGIN_ID) != null &&
+						item.getClass().isAssignableFrom(MultiJobProject.class));
+		}
+
+		/**
+		 * This method triggered from the client side by Ajax call.
+		 * The Element that trig is the "Refresh Repositories" button.
+		 *
+		 * @param url                           the artifactory url
+		 * @param credentialsUsername           override credentials user name
+		 * @param credentialsPassword           override credentials password
+		 * @param overridingDeployerCredentials user choose to override credentials
+		 * @return {@link org.jfrog.hudson.util.RefreshServerResponse} object that represents the response of the repositories
+		 */
+		@JavaScriptMethod
+		public RefreshServerResponse refreshFromArtifactory(String url, String credentialsUsername, String credentialsPassword, boolean overridingDeployerCredentials) {
+			RefreshServerResponse response = new RefreshServerResponse();
+			ArtifactoryServer artifactoryServer = RepositoriesUtils.getArtifactoryServer(url, RepositoriesUtils.getArtifactoryServers());
+
+			try {
+				List<String> releaseRepositoryKeysFirst = RepositoriesUtils.getLocalRepositories(url, credentialsUsername, credentialsPassword,
+						overridingDeployerCredentials, artifactoryServer);
+
+				Collections.sort(releaseRepositoryKeysFirst);
+				releaseRepositories = RepositoriesUtils.createRepositoriesList(releaseRepositoryKeysFirst);
+				response.setRepositories(releaseRepositories);
+				response.setSuccess(true);
+
+				return response;
+			} catch (Exception e) {
+				e.printStackTrace();
+				response.setResponseMessage(e.getMessage());
+				response.setSuccess(false);
+			}
+
+			return response;
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "Generic-Artifactory Integration";
+		}
+
+		@Override
+		public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+			req.bindParameters(this, "generic");
+			save();
+			return true;
+		}
+
+		public boolean isMultiConfProject() {
+			return (item.getClass().isAssignableFrom(MatrixProject.class));
+		}
+
+		public FormValidation doCheckArtifactoryCombinationFilter(@QueryParameter String value)
+				throws IOException, InterruptedException {
+			return FormValidations.validateArtifactoryCombinationFilter(value);
+		}
+
+		/**
+		 * Returns the list of {@link org.jfrog.hudson.ArtifactoryServer} configured.
+		 *
+		 * @return can be empty but never null.
+		 */
+		public List<ArtifactoryServer> getArtifactoryServers() {
+			return RepositoriesUtils.getArtifactoryServers();
+		}
+	}
 }

--- a/src/main/java/org/jfrog/hudson/generic/GenericArtifactsDeployer.java
+++ b/src/main/java/org/jfrog/hudson/generic/GenericArtifactsDeployer.java
@@ -38,192 +38,221 @@ import java.util.Set;
  * @author Shay Yaakov
  */
 public class GenericArtifactsDeployer {
-    private static final String SHA1 = "SHA1";
-    private static final String MD5 = "MD5";
+	private static final String SHA1 = "SHA1";
+	private static final String MD5 = "MD5";
 
-    private AbstractBuild build;
-    private ArtifactoryGenericConfigurator configurator;
-    private BuildListener listener;
-    private Credentials credentials;
-    private EnvVars env;
-    private List<Artifact> artifactsToDeploy = Lists.newArrayList();
+	private AbstractBuild build;
+	private ArtifactoryGenericConfigurator configurator;
+	private BuildListener listener;
+	private Credentials credentials;
+	private EnvVars env;
+	private List<Artifact> artifactsToDeploy = Lists.newArrayList();
 
-    public GenericArtifactsDeployer(AbstractBuild build, ArtifactoryGenericConfigurator configurator,
-                                    BuildListener listener, Credentials credentials)
-            throws IOException, InterruptedException, NoSuchAlgorithmException {
-        this.build = build;
-        this.configurator = configurator;
-        this.listener = listener;
-        this.credentials = credentials;
-        this.env = build.getEnvironment(listener);
-    }
+	public GenericArtifactsDeployer(AbstractBuild build, ArtifactoryGenericConfigurator configurator,
+									BuildListener listener, Credentials credentials)
+			throws IOException, InterruptedException, NoSuchAlgorithmException {
+		this.build = build;
+		this.configurator = configurator;
+		this.listener = listener;
+		this.credentials = credentials;
+		this.env = build.getEnvironment(listener);
+	}
 
-    public List<Artifact> getDeployedArtifacts() {
-        return artifactsToDeploy;
-    }
+	public List<Artifact> getDeployedArtifacts() {
+		return artifactsToDeploy;
+	}
 
-    public void deploy()
-            throws IOException, InterruptedException {
-        String deployPattern = Util.replaceMacro(configurator.getDeployPattern(), env);
-        deployPattern = StringUtils.replace(deployPattern, "\r\n", "\n");
-        deployPattern = StringUtils.replace(deployPattern, ",", "\n");
-        Multimap<String, String> pairs = PublishedItemsHelper.getPublishedItemsPatternPairs(deployPattern);
-        if (pairs.isEmpty()) {
-            return;
-        }
+	public void deploy()
+			throws IOException, InterruptedException {
+		String deployPattern = Util.replaceMacro(configurator.getDeployPattern(), env);
+		deployPattern = StringUtils.replace(deployPattern, "\r\n", "\n");
+		deployPattern = StringUtils.replace(deployPattern, ",", "\n");
+		Multimap<String, String> pairs = PublishedItemsHelper.getPublishedItemsPatternPairs(deployPattern);
+		if (pairs.isEmpty()) {
+			return;
+		}
 
-        FilePath workingDir = build.getWorkspace();
-        ArrayListMultimap<String, String> propertiesToAdd = getbuildPropertiesMap();
-        ArtifactoryServer artifactoryServer = configurator.getArtifactoryServer();
-        String repositoryKey = Util.replaceMacro(configurator.getRepositoryKey(), env);
-        artifactsToDeploy = workingDir.act(new FilesDeployerCallable(listener, pairs, artifactoryServer, credentials,
-                repositoryKey, propertiesToAdd,
-                artifactoryServer.createProxyConfiguration(Jenkins.getInstance().proxy)));
-    }
+		FilePath workingDir = build.getWorkspace();
+		ArrayListMultimap<String, String> propertiesToAdd = getbuildPropertiesMap();
+		ArtifactoryServer artifactoryServer = configurator.getArtifactoryServer();
+		String repositoryKey = Util.replaceMacro(configurator.getRepositoryKey(), env);
+		artifactsToDeploy = workingDir.act(new FilesDeployerCallable(listener, pairs, artifactoryServer, credentials,
+				repositoryKey, propertiesToAdd,
+				artifactoryServer.createProxyConfiguration(Jenkins.getInstance().proxy)));
+	}
 
-    private ArrayListMultimap<String, String> getbuildPropertiesMap() {
-        ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
+	private ArrayListMultimap<String, String> getbuildPropertiesMap() {
+		ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
 
-        properties.put("build.name", BuildUniqueIdentifierHelper.getBuildName(build));
-        properties.put("build.number", BuildUniqueIdentifierHelper.getBuildNumber(build));
-        properties.put("build.timestamp", build.getTimestamp().getTime().getTime() + "");
-        Cause.UpstreamCause parent = ActionableHelper.getUpstreamCause(build);
-        if (parent != null) {
-            properties.put("build.parentName", ExtractorUtils.sanitizeBuildName(parent.getUpstreamProject()));
-            properties.put("build.parentNumber", parent.getUpstreamBuild() + "");
-        }
-        String revision = ExtractorUtils.getVcsRevision(env);
-        if (StringUtils.isNotBlank(revision)) {
-            properties.put(BuildInfoFields.VCS_REVISION, revision);
-        }
+		properties.put("build.name", BuildUniqueIdentifierHelper.getBuildName(build));
+		properties.put("build.number", BuildUniqueIdentifierHelper.getBuildNumber(build));
+		properties.put("build.timestamp", build.getTimestamp().getTime().getTime() + "");
+		Cause.UpstreamCause parent = ActionableHelper.getUpstreamCause(build);
+		if (parent != null) {
+			properties.put("build.parentName", ExtractorUtils.sanitizeBuildName(parent.getUpstreamProject()));
+			properties.put("build.parentNumber", parent.getUpstreamBuild() + "");
+		}
+		String revision = ExtractorUtils.getVcsRevision(env);
+		if (StringUtils.isNotBlank(revision)) {
+			properties.put(BuildInfoFields.VCS_REVISION, revision);
+		}
 
-        addMatrixParams(properties);
+		addMatrixParams(properties);
 
-        return properties;
-    }
+		return properties;
+	}
 
-    private void addMatrixParams(Multimap<String, String> properties) {
-        String[] matrixParams = StringUtils.split(configurator.getMatrixParams(), ";");
-        if (matrixParams == null) {
-            return;
-        }
-        for (String matrixParam : matrixParams) {
-            String[] split = StringUtils.split(matrixParam, '=');
-            if (split.length == 2) {
-                String value = Util.replaceMacro(split[1], env);
-                //Space is not allowed in property key
-                properties.put(split[0].replace(" ", StringUtils.EMPTY), value);
-            }
-        }
-    }
+	private void addMatrixParams(Multimap<String, String> properties) {
+		String[] matrixParams = StringUtils.split(configurator.getMatrixParams(), ";");
+		if (matrixParams == null) {
+			return;
+		}
+		for (String matrixParam : matrixParams) {
+			String[] split = StringUtils.split(matrixParam, '=');
+			if (split.length == 2) {
+				String value = Util.replaceMacro(split[1], env);
+				//Space is not allowed in property key
+				properties.put(split[0].replace(" ", StringUtils.EMPTY), value);
+			}
+		}
+	}
 
-    private static class FilesDeployerCallable implements FilePath.FileCallable<List<Artifact>> {
+	private static class FilesDeployerCallable implements FilePath.FileCallable<List<Artifact>> {
 
-        private final String repositoryKey;
-        private BuildListener listener;
-        private Multimap<String, String> patternPairs;
-        private ArtifactoryServer server;
-        private Credentials credentials;
-        private ArrayListMultimap<String, String> buildProperties;
-        private ProxyConfiguration proxyConfiguration;
+		private final String repositoryKey;
+		private BuildListener listener;
+		private Multimap<String, String> patternPairs;
+		private ArtifactoryServer server;
+		private Credentials credentials;
+		private ArrayListMultimap<String, String> buildProperties;
+		private ProxyConfiguration proxyConfiguration;
 
-        public FilesDeployerCallable(BuildListener listener, Multimap<String, String> patternPairs,
-                                     ArtifactoryServer server, Credentials credentials, String repositoryKey,
-                                     ArrayListMultimap<String, String> buildProperties, ProxyConfiguration proxyConfiguration) {
-            this.listener = listener;
-            this.patternPairs = patternPairs;
-            this.server = server;
-            this.credentials = credentials;
-            this.repositoryKey = repositoryKey;
-            this.buildProperties = buildProperties;
-            this.proxyConfiguration = proxyConfiguration;
-        }
+		public FilesDeployerCallable(BuildListener listener, Multimap<String, String> patternPairs,
+									ArtifactoryServer server, Credentials credentials, String repositoryKey,
+									ArrayListMultimap<String, String> buildProperties, ProxyConfiguration proxyConfiguration) {
+			this.listener = listener;
+			this.patternPairs = patternPairs;
+			this.server = server;
+			this.credentials = credentials;
+			this.repositoryKey = repositoryKey;
+			this.buildProperties = buildProperties;
+			this.proxyConfiguration = proxyConfiguration;
+		}
 
-        public List<Artifact> invoke(File workspace, VirtualChannel channel) throws IOException, InterruptedException {
-            Multimap<String, File> targetPathToFilesMap = buildTargetPathToFiles(workspace);
-            Set<DeployDetails> artifactsToDeploy = Sets.newHashSet();
-            for (Map.Entry<String, File> entry : targetPathToFilesMap.entries()) {
-                artifactsToDeploy.addAll(buildDeployDetailsFromFileEntry(entry));
-            }
+		public List<Artifact> invoke(File workspace, VirtualChannel channel) throws IOException, InterruptedException {
+			Multimap<String, File> targetPathToFilesMap = buildTargetPathToFiles(workspace);
+			Set<DeployDetails> artifactsToDeploy = Sets.newHashSet();
+			for (Map.Entry<String, File> entry : targetPathToFilesMap.entries()) {
+				artifactsToDeploy.addAll(buildDeployDetailsFromFileEntry(entry));
+			}
 
-            ArtifactoryBuildInfoClient client = server.createArtifactoryClient(credentials.getUsername(),
-                    credentials.getPassword(), proxyConfiguration);
-            try {
-                deploy(client, artifactsToDeploy);
-                return convertDeployDetailsToArtifacts(artifactsToDeploy);
-            } finally {
-                client.shutdown();
-            }
-        }
+			ArtifactoryBuildInfoClient client = server.createArtifactoryClient(credentials.getUsername(),
+					credentials.getPassword(), proxyConfiguration);
+			try {
+				deploy(client, artifactsToDeploy);
+				return convertDeployDetailsToArtifacts(artifactsToDeploy);
+			} finally {
+				client.shutdown();
+			}
+		}
 
-        private List<Artifact> convertDeployDetailsToArtifacts(Set<DeployDetails> details) {
-            List<Artifact> result = Lists.newArrayList();
-            for (DeployDetails detail : details) {
-                String ext = FilenameUtils.getExtension(detail.getFile().getName());
-                Artifact artifact = new ArtifactBuilder(detail.getFile().getName()).md5(detail.getMd5())
-                        .sha1(detail.getSha1()).type(ext).build();
-                result.add(artifact);
-            }
-            return result;
-        }
+		private List<Artifact> convertDeployDetailsToArtifacts(Set<DeployDetails> details) {
+			List<Artifact> result = Lists.newArrayList();
+			for (DeployDetails detail : details) {
+				String ext = FilenameUtils.getExtension(detail.getFile().getName());
+				Artifact artifact = new ArtifactBuilder(detail.getFile().getName()).md5(detail.getMd5())
+						.sha1(detail.getSha1()).type(ext).build();
+				result.add(artifact);
+			}
+			return result;
+		}
 
-        public void deploy(ArtifactoryBuildInfoClient client, Set<DeployDetails> artifactsToDeploy)
-                throws IOException {
-            for (DeployDetails deployDetail : artifactsToDeploy) {
-                StringBuilder deploymentPathBuilder = new StringBuilder(server.getUrl());
-                deploymentPathBuilder.append("/").append(repositoryKey);
-                if (!deployDetail.getArtifactPath().startsWith("/")) {
-                    deploymentPathBuilder.append("/");
-                }
-                deploymentPathBuilder.append(deployDetail.getArtifactPath());
-                listener.getLogger().println("Deploying artifact: " + deploymentPathBuilder.toString());
-                client.deployArtifact(deployDetail);
-            }
-        }
+		public void deploy(ArtifactoryBuildInfoClient client, Set<DeployDetails> artifactsToDeploy)
+				throws IOException {
+			for (DeployDetails deployDetail : artifactsToDeploy) {
+				StringBuilder deploymentPathBuilder = new StringBuilder(server.getUrl());
+				deploymentPathBuilder.append("/").append(repositoryKey);
+				if (!deployDetail.getArtifactPath().startsWith("/")) {
+					deploymentPathBuilder.append("/");
+				}
+				deploymentPathBuilder.append(deployDetail.getArtifactPath());
+				listener.getLogger().println("Deploying artifact: " + deploymentPathBuilder.toString());
+				client.deployArtifact(deployDetail);
+			}
+		}
 
-        private Multimap<String, File> buildTargetPathToFiles(File workspace) throws IOException {
-            Multimap<String, File> result = HashMultimap.create();
-            for (Map.Entry<String, String> entry : patternPairs.entries()) {
-                String pattern = entry.getKey();
-                String targetPath = entry.getValue();
-                Multimap<String, File> publishingData = PublishedItemsHelper.buildPublishingData(workspace, pattern,
-                        targetPath);
-                if (publishingData != null) {
-                    listener.getLogger().println(
-                            "For pattern: " + pattern + " " + publishingData.size() + " artifacts were found");
-                    result.putAll(publishingData);
-                } else {
-                    listener.getLogger().println("For pattern: " + pattern + " no artifacts were found");
-                }
-            }
+		private Multimap<String, File> buildTargetPathToFiles(File workspace) throws IOException {
+			Multimap<String, File> result = HashMultimap.create();
+			for (Map.Entry<String, String> entry : patternPairs.entries()) {
+				String pattern = entry.getKey();
+				String targetPath = entry.getValue();
+				Multimap<String, File> publishingData = PublishedItemsHelper.buildPublishingData(workspace, pattern,
+						targetPath);
+				
+				/*boolean overrideDefaultRelativePath = true;
+				if(overrideDefaultRelativePath) {
+					publishingData = overrideRelativePath(publishingData, targetPath);
+				}*/
+				//if(configurator.is)
+				
+				/*publishingData.clear();
+				File f = new File("D:\\workspace\\artifactory-plugin\\work\\jobs\\Artifactory-Test\\workspace\\target\\path\\to\\zaproxy.jar");
+				publishingData.put(targetPath+"/my/path", f);*/
+				
+				listener.getLogger().println("From buildTargetPathToFiles: pattern = " + pattern);
+				listener.getLogger().println("From buildTargetPathToFiles: targetPath = " + targetPath);
+				listener.getLogger().println("From buildTargetPathToFiles: publishingData = " + publishingData);
+				
+				if (publishingData != null) {
+					listener.getLogger().println(
+							"For pattern: " + pattern + " " + publishingData.size() + " artifacts were found");
+					result.putAll(publishingData);
+				} else {
+					listener.getLogger().println("For pattern: " + pattern + " no artifacts were found");
+				}
+			}
 
-            return result;
-        }
+			return result;
+		}
+		
+		private Multimap<String, File> overrideRelativePath(Multimap<String, File> publishingData, String targetPath) {
+			Multimap<String, File> result = HashMultimap.create();
+			
+			for(File f : publishingData.values()) {
+				result.put(targetPath, f);
+			}
+			
+			return result;
+		}
 
-        private Set<DeployDetails> buildDeployDetailsFromFileEntry(Map.Entry<String, File> fileEntry)
-                throws IOException {
-            Set<DeployDetails> result = Sets.newHashSet();
-            String targetPath = fileEntry.getKey();
-            File artifactFile = fileEntry.getValue();
-            String path = PublishedItemsHelper.calculateTargetPath(targetPath, artifactFile);
-            path = StringUtils.replace(path, "//", "/");
+		private Set<DeployDetails> buildDeployDetailsFromFileEntry(Map.Entry<String, File> fileEntry)
+				throws IOException {
+			Set<DeployDetails> result = Sets.newHashSet();
+			String targetPath = fileEntry.getKey();
+			File artifactFile = fileEntry.getValue();
+			String path = PublishedItemsHelper.calculateTargetPath(targetPath, artifactFile);
+			path = StringUtils.replace(path, "//", "/");
+			
+			listener.getLogger().println("From buildDeployDetailsFromFileEntry: targetPath = " + targetPath);
+			listener.getLogger().println("From buildDeployDetailsFromFileEntry: artifactFile = " + artifactFile);
+			listener.getLogger().println("From buildDeployDetailsFromFileEntry: path = " + path);
 
-            // calculate the sha1 checksum that is not given by Jenkins and add it to the deploy artifactsToDeploy
-            Map<String, String> checksums = Maps.newHashMap();
-            try {
-                checksums = FileChecksumCalculator.calculateChecksums(artifactFile, SHA1, MD5);
-            } catch (NoSuchAlgorithmException e) {
-                listener.getLogger().println("Could not find checksum algorithm for " + SHA1 + " or " + MD5);
-            }
-            DeployDetails.Builder builder = new DeployDetails.Builder()
-                    .file(artifactFile)
-                    .artifactPath(path)
-                    .targetRepository(repositoryKey)
-                    .md5(checksums.get(MD5)).sha1(checksums.get(SHA1))
-                    .addProperties(buildProperties);
-            result.add(builder.build());
+			// calculate the sha1 checksum that is not given by Jenkins and add it to the deploy artifactsToDeploy
+			Map<String, String> checksums = Maps.newHashMap();
+			try {
+				checksums = FileChecksumCalculator.calculateChecksums(artifactFile, SHA1, MD5);
+			} catch (NoSuchAlgorithmException e) {
+				listener.getLogger().println("Could not find checksum algorithm for " + SHA1 + " or " + MD5);
+			}
+			DeployDetails.Builder builder = new DeployDetails.Builder()
+					.file(artifactFile)
+					.artifactPath(path)
+					.targetRepository(repositoryKey)
+					.md5(checksums.get(MD5)).sha1(checksums.get(SHA1))
+					.addProperties(buildProperties);
+			result.add(builder.build());
 
-            return result;
-        }
-    }
+			return result;
+		}
+	}
 }

--- a/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
@@ -1,136 +1,150 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:r="/lib/jfrog" xmlns:st="jelly:stapler">
-    <f:section title="${%Artifactory Configuration}">
-        <f:dropdownList name="details" title="${%Artifactory server}">
-            <j:forEach var="s" items="${descriptor.artifactoryServers}" varStatus="loop">
-                <f:dropdownListBlock value="${s.name}" title="${s.url}" selected="${s.name==instance.artifactoryName}">
-                    <f:nested>
-                        <input type="hidden" name="artifactoryName" value="${s.name}"/>
-                        <input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.url}" value="${s.url}"/>
-                        <input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
+<f:section title="${%Artifactory Configuration}">
+	<f:dropdownList name="details" title="${%Artifactory server}">
+	<j:forEach var="s" items="${descriptor.artifactoryServers}" varStatus="loop">
+		<f:dropdownListBlock value="${s.name}" title="${s.url}" selected="${s.name==instance.artifactoryName}">
+		<f:nested>
+			<input type="hidden" name="artifactoryName" value="${s.name}"/>
+			<input type="hidden" name="artifactoryUrl" id="artifactoryUrlDeploy${s.url}" value="${s.url}"/>
+			<input type="hidden" name="stapler-class" value="org.jfrog.hudson.ServerDetails"/>
 
-                        <r:dynamicRepos id="genericRepositoryKeys-${s.url}"
-                                        title="Target Repository"
-                                        field="deployReleaseRepository"
-                                        repositoryConf="${instance.details.deployReleaseRepository}"
-                                        repositories="${instance.releaseRepositoryList}"
-                                        helpUrl="/plugin/artifactory/help/common/help-deployRepository.html"/>
+			<r:dynamicRepos id="genericRepositoryKeys-${s.url}"
+					title="Target Repository"
+					field="deployReleaseRepository"
+					repositoryConf="${instance.details.deployReleaseRepository}"
+					repositories="${instance.releaseRepositoryList}"
+					helpUrl="/plugin/artifactory/help/common/help-deployRepository.html"/>
 
-                        <script>
-                            var genericDeployBind =
-                            <st:bind value="${descriptor}"/>
-                        </script>
-                        <r:repos title="${%Refresh Repositories}" progress="${%Refreshing...}"
-                                 bind="genericDeployBind"
-                                 jsFunction="artifactoryGenericConfigurator"
-                                 repoUrl="artifactoryUrlDeploy${s.url}"
-                                 credentialUserName="$('overridingDeployerCredentials-generic').down('input[type=text]').value"
-                                 credentialPassword="$('overridingDeployerCredentials-generic').down('input[type=password]').value"
-                                 isCredential="$('overridingDeployerCredentials-generic').down('input').checked"/>
+			<script>
+			var genericDeployBind =
+			<st:bind value="${descriptor}"/>
+			</script>
+			<r:repos title="${%Refresh Repositories}" progress="${%Refreshing...}"
+				bind="genericDeployBind"
+				jsFunction="artifactoryGenericConfigurator"
+				repoUrl="artifactoryUrlDeploy${s.url}"
+				credentialUserName="$('overridingDeployerCredentials-generic').down('input[type=text]').value"
+				credentialPassword="$('overridingDeployerCredentials-generic').down('input[type=password]').value"
+				isCredential="$('overridingDeployerCredentials-generic').down('input').checked"/>
 
-                    </f:nested>
-                </f:dropdownListBlock>
-            </j:forEach>
-        </f:dropdownList>
-        <f:block>
-            <table style="width:100%" id="overridingDeployerCredentials-generic">
-                <j:set var="overridingDeployerCredentials" value="${instance.overridingDeployerCredentials}"/>
-                <f:optionalBlock name="overridingDeployerCredentials" checked="${overridingDeployerCredentials != null}"
-                                 title="Override default deployer credentials"
-                                 help="/plugin/artifactory/help/common/help-overridingDeployerCredentials.html">
-                    <input type="hidden" name="stapler-class" value="org.jfrog.hudson.util.Credentials"/>
-                    <f:entry title="User Name" help="/plugin/artifactory/help/common/help-deployerUserName.html"
-                             field="username">
-                        <f:textbox value="${overridingDeployerCredentials.username}"/>
-                    </f:entry>
-                    <f:entry title="Password" field="password"
-                             help="/plugin/artifactory/help/common/help-deployerPassword.html">
-                        <f:password value="${overridingDeployerCredentials.password}"/>
-                    </f:entry>
-                </f:optionalBlock>
-            </table>
-        </f:block>
-        <f:block>
-            <table style="width:100%">
-                <f:entry title="Resolved Artifacts (requires Artifactory Pro)" field="resolvePattern"
-                         help="/plugin/artifactory/help/common/help-resolvePattern.html">
-                    <f:textarea value="${instance.resolvePattern}"/>
-                </f:entry>
-                <f:entry title="Published Artifacts" field="deployPattern"
-                         help="/plugin/artifactory/help/common/help-deployPattern.html">
-                    <f:textarea value="${instance.deployPattern}"/>
-                </f:entry>
-                <f:entry title="Deployment properties" field="matrixParams"
-                         help="/plugin/artifactory/help/common/help-matrixParams.html">
-                    <f:textbox value="${instance.matrixParams}"/>
-                </f:entry>
-            </table>
-        </f:block>
-        <f:block>
-            <table style="width:100%">
-                <f:optionalBlock name="deployBuildInfo" checked="${h.defaultToTrue(instance.deployBuildInfo)}"
-                                 title="Capture and publish build info"
-                                 help="/plugin/artifactory/help/common/help-deployBuildInfo.html"
-                                 inline="true">
+		</f:nested>
+		</f:dropdownListBlock>
+	</j:forEach>
+	</f:dropdownList>
+	<f:block>
+	<table style="width:100%" id="overridingDeployerCredentials-generic">
+		<j:set var="overridingDeployerCredentials" value="${instance.overridingDeployerCredentials}"/>
+		<f:optionalBlock name="overridingDeployerCredentials" checked="${overridingDeployerCredentials != null}"
+				title="Override default deployer credentials"
+				help="/plugin/artifactory/help/common/help-overridingDeployerCredentials.html">
+		<input type="hidden" name="stapler-class" value="org.jfrog.hudson.util.Credentials"/>
+		<f:entry title="User Name" help="/plugin/artifactory/help/common/help-deployerUserName.html"
+			field="username">
+			<f:textbox value="${overridingDeployerCredentials.username}"/>
+		</f:entry>
+		<f:entry title="Password" field="password"
+			help="/plugin/artifactory/help/common/help-deployerPassword.html">
+			<f:password value="${overridingDeployerCredentials.password}"/>
+		</f:entry>
+		</f:optionalBlock>
+	</table>
+	</f:block>
+	<f:block>
+	<table style="width:100%">
+		<f:entry title="Resolved Artifacts (requires Artifactory Pro)" field="resolvePattern"
+			help="/plugin/artifactory/help/common/help-resolvePattern.html">
+		<f:textarea value="${instance.resolvePattern}"/>
+		</f:entry>
+		
+			<f:optionalBlock field="removeRelativePath"
+				help="/plugin/artifactory/help/common/help-removeRelativePath.html"
+				title="${%Override/Remove Original Relative Path}"
+				checked="${instance.removeRelativePath}"
+				inline="true">
+			</f:optionalBlock>
+			<!--<f:entry field="removeRelativePath" title="${%Override/Remove Original Relative Path}"
+			help="/plugin/artifactory/help/common/help-removeRelativePath.html">
+			<f:checkbox default="true" checked="${instance.removeRelativePath}"/>-->
+			<!--<label class="attach-previous">${%Override/Remove Original Relative Path}</label>-->
+		<!--</f:entry>-->
+		
+		
+		<f:entry title="Published Artifacts" field="deployPattern"
+			help="/plugin/artifactory/help/common/help-deployPattern.html">
+		<f:textarea value="${instance.deployPattern}"/>
+		</f:entry>
+		<f:entry title="Deployment properties" field="matrixParams"
+			help="/plugin/artifactory/help/common/help-matrixParams.html">
+		<f:textbox value="${instance.matrixParams}"/>
+		</f:entry>
+	</table>
+	</f:block>
+	<f:block>
+	<table style="width:100%">
+		<f:optionalBlock name="deployBuildInfo" checked="${h.defaultToTrue(instance.deployBuildInfo)}"
+				title="Capture and publish build info"
+				help="/plugin/artifactory/help/common/help-deployBuildInfo.html"
+				inline="true">
 
-                    <f:optionalBlock name="includeEnvVars" checked="${instance.includeEnvVars}"
-                                     title="Include environment variables"
-                                     help="/plugin/artifactory/help/common/help-includeEnvVars.html"
-                                     inline="true">
-                        <f:block>
-                            <table style="width:100%">
-                                <j:set var="envVarsPatterns" value="${instance.envVarsPatterns}"/>
-                                <f:section name="envVarsPatterns">
-                                    <input type="hidden" name="stapler-class"
-                                           value="org.jfrog.hudson.util.IncludesExcludes"/>
-                                    <f:entry title="Include Patterns" field="includePatterns"
-                                             help="/plugin/artifactory/help/common/help-envVarsIncludePatterns.html">
-                                        <f:textbox value="${envVarsPatterns.includePatterns}"/>
-                                    </f:entry>
-                                    <f:entry title="Exclude Patterns"
-                                             field="excludePatterns"
-                                             help="/plugin/artifactory/help/common/help-envVarsExcludePatterns.html">
-                                        <f:textbox value="${envVarsPatterns.excludePatterns}"
-                                                   default="*password*,*secret*"/>
-                                    </f:entry>
-                                </f:section>
-                            </table>
-                        </f:block>
-                    </f:optionalBlock>
-                    <f:optionalBlock name="discardOldBuilds"
-                                     checked="${instance.discardOldBuilds}"
-                                     title="Discard old builds from Artifactory (requires Artifactory Pro)"
-                                     inline="true"
-                                     help="/plugin/artifactory/help/common/help-discardBuilds.html">
-                        <f:entry field="discardBuildArtifacts"
-                                 help="/plugin/artifactory/help/common/help-discardBuildArtifacts.html">
-                            <f:checkbox default="true" checked="${instance.discardBuildArtifacts}"/>
-                            <label class="attach-previous">${%Discard build artifacts}</label>
-                        </f:entry>
-                    </f:optionalBlock>
-                </f:optionalBlock>
-            </table>
-        </f:block>
-        <f:block>
-            <j:if test="${descriptor.isMultiConfProject()}">
-                <f:block>
-                    <table style="width:100%">
-                        <f:optionalBlock name="multiConfProject"
-                                         checked="${instance.multiConfProject == null || instance.multiConfProject}"
-                                         title="${%Multi Configuration Deploy Matcher}"
-                                         inline="true">
-                            <f:entry field="artifactoryCombinationFilter" title="${%Combination Matches}"
-                                     description="Groovy expression"
-                                     help="/plugin/artifactory/help/common/help-combinationFilter.html">
-                                <f:textbox value="${instance.artifactoryCombinationFilter}"
-                                           field="artifactoryCombinationFilter"/>
-                            </f:entry>
-                        </f:optionalBlock>
-                    </table>
-                </f:block>
-            </j:if>
-        </f:block>
-    </f:section>
-    <f:block>
-        <hr/>
-    </f:block>
+		<f:optionalBlock name="includeEnvVars" checked="${instance.includeEnvVars}"
+				title="Include environment variables"
+				help="/plugin/artifactory/help/common/help-includeEnvVars.html"
+				inline="true">
+			<f:block>
+			<table style="width:100%">
+				<j:set var="envVarsPatterns" value="${instance.envVarsPatterns}"/>
+				<f:section name="envVarsPatterns">
+				<input type="hidden" name="stapler-class"
+					value="org.jfrog.hudson.util.IncludesExcludes"/>
+				<f:entry title="Include Patterns" field="includePatterns"
+					help="/plugin/artifactory/help/common/help-envVarsIncludePatterns.html">
+					<f:textbox value="${envVarsPatterns.includePatterns}"/>
+				</f:entry>
+				<f:entry title="Exclude Patterns"
+					field="excludePatterns"
+					help="/plugin/artifactory/help/common/help-envVarsExcludePatterns.html">
+					<f:textbox value="${envVarsPatterns.excludePatterns}"
+						default="*password*,*secret*"/>
+				</f:entry>
+				</f:section>
+			</table>
+			</f:block>
+		</f:optionalBlock>
+		<f:optionalBlock name="discardOldBuilds"
+				checked="${instance.discardOldBuilds}"
+				title="Discard old builds from Artifactory (requires Artifactory Pro)"
+				inline="true"
+				help="/plugin/artifactory/help/common/help-discardBuilds.html">
+			<f:entry field="discardBuildArtifacts"
+				help="/plugin/artifactory/help/common/help-discardBuildArtifacts.html">
+			<f:checkbox default="true" checked="${instance.discardBuildArtifacts}"/>
+			<label class="attach-previous">${%Discard build artifacts}</label>
+			</f:entry>
+		</f:optionalBlock>
+		</f:optionalBlock>
+	</table>
+	</f:block>
+	<f:block>
+	<j:if test="${descriptor.isMultiConfProject()}">
+		<f:block>
+		<table style="width:100%">
+			<f:optionalBlock name="multiConfProject"
+					checked="${instance.multiConfProject == null || instance.multiConfProject}"
+					title="${%Multi Configuration Deploy Matcher}"
+					inline="true">
+			<f:entry field="artifactoryCombinationFilter" title="${%Combination Matches}"
+				description="Groovy expression"
+				help="/plugin/artifactory/help/common/help-combinationFilter.html">
+				<f:textbox value="${instance.artifactoryCombinationFilter}"
+					field="artifactoryCombinationFilter"/>
+			</f:entry>
+			</f:optionalBlock>
+		</table>
+		</f:block>
+	</j:if>
+	</f:block>
+</f:section>
+<f:block>
+	<hr/>
+</f:block>
 </j:jelly>

--- a/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
@@ -56,18 +56,12 @@
 		<f:textarea value="${instance.resolvePattern}"/>
 		</f:entry>
 		
-			<f:optionalBlock field="removeRelativePath"
-				help="/plugin/artifactory/help/common/help-removeRelativePath.html"
-				title="${%Override/Remove Original Relative Path}"
-				checked="${instance.removeRelativePath}"
-				inline="true">
-			</f:optionalBlock>
-			<!--<f:entry field="removeRelativePath" title="${%Override/Remove Original Relative Path}"
-			help="/plugin/artifactory/help/common/help-removeRelativePath.html">
-			<f:checkbox default="true" checked="${instance.removeRelativePath}"/>-->
-			<!--<label class="attach-previous">${%Override/Remove Original Relative Path}</label>-->
-		<!--</f:entry>-->
-		
+		<f:optionalBlock field="removeRelativePath"
+			help="/plugin/artifactory/help/common/help-removeRelativePath.html"
+			title="${%Override/Remove Original Relative Path}"
+			checked="${instance.removeRelativePath}"
+			inline="true">
+		</f:optionalBlock>		
 		
 		<f:entry title="Published Artifacts" field="deployPattern"
 			help="/plugin/artifactory/help/common/help-deployPattern.html">

--- a/src/main/webapp/help/common/help-removeRelativePath.html
+++ b/src/main/webapp/help/common/help-removeRelativePath.html
@@ -1,0 +1,4 @@
+<div>
+	Remove the original relative path for each file. So, you can define your own path to each file with the 
+	below text area. See Ant-Style wildcards.
+</div>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-27221

A simple checkbox was added to override/remove the original relative path to each file.
If this checkbox is checked, so the relative path to each file is removed and you can specify your own path with the "Published Artifacts" text area doing this for example:

 *****/****.zip=>myDir/winFiles - Deploys all zip files under the working directory to the myDir/winFiles directory of the target repository, REMOVING the original relative path for each file.