### PR TITLE
Add null guard to prevent NPE

### DIFF
--- a/src/main/java/org/jfrog/hudson/util/ConcurrentJobsHelper.java
+++ b/src/main/java/org/jfrog/hudson/util/ConcurrentJobsHelper.java
@@ -70,7 +70,7 @@ public class ConcurrentJobsHelper {
     public static abstract class ConcurrentBuildTearDownSync {
         public ConcurrentBuildTearDownSync(String buildName, Result buildResult) {
             ConcurrentBuild build = concurrentBuildHandler.get(buildName);
-            if (build.getThreadsCounter().decrementAndGet() == 0 || Result.ABORTED.equals(buildResult)) {
+            if ((build != null && build.getThreadsCounter().decrementAndGet() == 0) || Result.ABORTED.equals(buildResult)) {
                 tearDown();
                 concurrentBuildHandler.remove(buildName);
             }


### PR DESCRIPTION
Protects against a NPE observed. Not sure why it was null in the first place.

16:39:03 FATAL: null
16:39:03 java.lang.NullPointerException
16:39:03 	at org.jfrog.hudson.util.ConcurrentJobsHelper$ConcurrentBuildTearDownSync.<init>(ConcurrentJobsHelper.java:73)
16:39:03 	at org.jfrog.hudson.gradle.ArtifactoryGradleConfigurator$2$1.<init>(ArtifactoryGradleConfigurator.java:547)
16:39:03 	at org.jfrog.hudson.gradle.ArtifactoryGradleConfigurator$2.tearDown(ArtifactoryGradleConfigurator.java:547)
16:39:03 	at hudson.model.Build$BuildExecution.doRun(Build.java:171)
16:39:03 	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:536)
16:39:03 	at hudson.model.Run.execute(Run.java:1741)
16:39:03 	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
16:39:03 	at hudson.model.ResourceController.execute(ResourceController.java:98)
16:39:03 	at hudson.model.Executor.run(Executor.java:374)