### PR TITLE
Adding next development version to the comment

### DIFF
--- a/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseAction/index.jelly
@@ -84,7 +84,7 @@
                         <f:entry title="${%Next development version comment}" field="nextDevelCommitComment"
                                  help="/plugin/artifactory/help/release/ReleaseAction/help-nextDevelopmentComment.html">
                             <f:textarea rows="3" name="nextDevelCommitComment"
-                                        default="${it.defaultVcsConfig.nextDevelopmentVersionComment}"/>
+                                        default="${it.defaultVcsConfig.nextDevelopmentVersionComment} ${it.defaultGlobalNextDevelopmentVersion}"/>
                         </f:entry>
                     </f:section>
                     <f:block>


### PR DESCRIPTION
I find that I'm always pasting the next version into the field anyway. This also help to view that the change actually made it to the master branch.