### PR TITLE
Resolve environment variables in spec of pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <buildinfo.version>2.6.5</buildinfo.version>
         <buildinfo.maven3.version>2.6.1</buildinfo.maven3.version>
-        <buildinfo.gradle.version>4.4.8</buildinfo.gradle.version>
+        <buildinfo.gradle.version>4.4.x-SNAPSHOT</buildinfo.gradle.version>
         <buildinfo.ivy.version>2.6.1</buildinfo.ivy.version>
         <maven-release-plugin.version>2.2</maven-release-plugin.version>
     </properties>

--- a/src/main/java/org/jfrog/hudson/pipeline/steps/DownloadStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/DownloadStep.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.steps.*;
@@ -61,7 +62,7 @@ public class DownloadStep extends AbstractStepImpl {
 
         @Override
         protected BuildInfo run() throws Exception {
-            BuildInfo buildInfo = new GenericDownloadExecutor(Utils.prepareArtifactoryServer(null, step.getServer()), this.listener, this.build, this.ws, step.getBuildInfo()).execution(step.getSpec());
+            BuildInfo buildInfo = new GenericDownloadExecutor(Utils.prepareArtifactoryServer(null, step.getServer()), this.listener, this.build, this.ws, step.getBuildInfo()).execution(Util.replaceMacro(step.getSpec(), env));
             new BuildInfoAccessor(buildInfo).captureVariables(env, build, listener);
             return buildInfo;
         }

--- a/src/main/java/org/jfrog/hudson/pipeline/steps/UploadStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/UploadStep.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
@@ -62,7 +63,7 @@ public class UploadStep extends AbstractStepImpl {
 
         @Override
         protected BuildInfo run() throws Exception {
-            BuildInfo buildInfo = new GenericUploadExecutor(Utils.prepareArtifactoryServer(null, step.getServer()), listener, build, ws, step.getBuildInfo(), getContext()).execution(step.getSpec());
+            BuildInfo buildInfo = new GenericUploadExecutor(Utils.prepareArtifactoryServer(null, step.getServer()), listener, build, ws, step.getBuildInfo(), getContext()).execution(Util.replaceMacro(step.getSpec(), env));
             new BuildInfoAccessor(buildInfo).captureVariables(env, build, listener);
             return buildInfo;
         }

--- a/src/main/java/org/jfrog/hudson/release/scm/git/GitCoordinator.java
+++ b/src/main/java/org/jfrog/hudson/release/scm/git/GitCoordinator.java
@@ -51,12 +51,12 @@ public class GitCoordinator extends AbstractScmCoordinator {
     public void prepare() throws IOException, InterruptedException {
         releaseBranch = releaseAction.getReleaseBranch();
 
-        // find the current local built branch
-        String gitBranchName = build.getEnvironment(listener).get("GIT_BRANCH");
-        checkoutBranch = StringUtils.substringAfter(gitBranchName, "/");
-
         scmManager = new GitManager(build, listener);
         scmManager.setGitCredentials(releaseAction.getGitCredentials());
+
+        // find the current local built branch
+        String gitBranchName = build.getEnvironment(listener).get("GIT_BRANCH");
+        checkoutBranch = scmManager.getBranchNameWithoutRemote(gitBranchName);
     }
 
     public void beforeReleaseVersionChange() throws IOException, InterruptedException {

--- a/src/main/java/org/jfrog/hudson/release/scm/git/GitManager.java
+++ b/src/main/java/org/jfrog/hudson/release/scm/git/GitManager.java
@@ -144,6 +144,17 @@ public class GitManager extends AbstractScmManager<GitSCM> {
         return defaultRemoteUrl;
     }
 
+    public String getBranchNameWithoutRemote(String branchName) {
+        List<RemoteConfig> repositories = getJenkinsScm().getRepositories();
+        for (RemoteConfig remoteConfig : repositories) {
+            String prefix = remoteConfig.getName() + "/";
+            if (branchName.startsWith(prefix)) {
+                return StringUtils.removeStart(branchName, prefix);
+            }
+        }
+        return branchName;
+    }
+
     public ReleaseRepository getRemoteConfig(String defaultRemoteNameOrUrl) throws IOException {
         List<RemoteConfig> repositories = getJenkinsScm().getRepositories();
         if (StringUtils.isBlank(defaultRemoteNameOrUrl)) {


### PR DESCRIPTION
Currently environment variable placeholders are only replaced in upload/download specs when used with Generic Plugin. However when using with pipelines this is missing but needed in case specs get loaded from files.