### PR TITLE
Add serialVersionUID to anonym classes

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/docker/proxy/BuildInfoProxyManager.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/docker/proxy/BuildInfoProxyManager.java
@@ -12,14 +12,14 @@ import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.List;
 import java.util.logging.Logger;
 
 /**
  * Created by romang on 7/10/16.
  */
-public class BuildInfoProxyManager {
-
+public class BuildInfoProxyManager implements Serializable {
     static private HttpProxyServer server = null;
     private static final Logger logger = Logger.getLogger(BuildInfoProxyManager.class.getName());
 
@@ -65,6 +65,7 @@ public class BuildInfoProxyManager {
                 continue;
             }
             node.getChannel().call(new Callable<Boolean, IOException>() {
+                private static final long serialVersionUID = 1L;
                 public Boolean call() throws IOException {
                     BuildInfoProxyManager.stop();
                     return true;
@@ -98,6 +99,7 @@ public class BuildInfoProxyManager {
             localKeyPath.copyTo(remoteKeyPath);
 
             node.getChannel().call(new Callable<Boolean, IOException>() {
+                private static final long serialVersionUID = 1L;
                 public Boolean call() throws IOException {
                     BuildInfoProxyManager.start(port, agentCertPath, agentKeyPath);
                     return true;

--- a/src/main/java/org/jfrog/hudson/pipeline/docker/proxy/BuildInfoProxyManager.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/docker/proxy/BuildInfoProxyManager.java
@@ -19,7 +19,7 @@ import java.util.logging.Logger;
 /**
  * Created by romang on 7/10/16.
  */
-public class BuildInfoProxyManager implements Serializable {
+public class BuildInfoProxyManager {
     static private HttpProxyServer server = null;
     private static final Logger logger = Logger.getLogger(BuildInfoProxyManager.class.getName());
 


### PR DESCRIPTION
Add serialVersionUID to anonym classes in order to prevent serialization issue in BuildInfoProxyManager during save configurations in Jenkins