### PR TITLE
introduce deployRetryCount

### DIFF
--- a/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
@@ -66,6 +66,7 @@ public class ArtifactoryGenericConfigurator extends BuildWrapper implements Depl
     private final IncludesExcludes envVarsPatterns;
     private final boolean discardOldBuilds;
     private final boolean discardBuildArtifacts;
+    private final int deployRetryCount;
     private transient List<Dependency> publishedDependencies;
     private transient List<BuildDependency> buildDependencies;
     private String artifactoryCombinationFilter;
@@ -93,6 +94,7 @@ public class ArtifactoryGenericConfigurator extends BuildWrapper implements Depl
                                           boolean includeEnvVars, IncludesExcludes envVarsPatterns,
                                           boolean discardOldBuilds,
                                           boolean discardBuildArtifacts,
+                                          int deployRetryCount,
                                           boolean multiConfProject,
                                           String artifactoryCombinationFilter,
                                           String customBuildName,
@@ -112,6 +114,7 @@ public class ArtifactoryGenericConfigurator extends BuildWrapper implements Depl
         this.envVarsPatterns = envVarsPatterns;
         this.discardOldBuilds = discardOldBuilds;
         this.discardBuildArtifacts = discardBuildArtifacts;
+        this.deployRetryCount = deployRetryCount;
         this.multiConfProject = multiConfProject;
         this.artifactoryCombinationFilter = artifactoryCombinationFilter;
         this.customBuildName = customBuildName;
@@ -223,6 +226,10 @@ public class ArtifactoryGenericConfigurator extends BuildWrapper implements Depl
 
     public boolean isDiscardBuildArtifacts() {
         return discardBuildArtifacts;
+    }
+
+    public int getDeployRetryCount() {
+        return deployRetryCount;
     }
 
     public boolean isEnableIssueTrackerIntegration() {

--- a/src/main/java/org/jfrog/hudson/pipeline/executors/GenericUploadExecutor.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/executors/GenericUploadExecutor.java
@@ -35,14 +35,16 @@ public class GenericUploadExecutor {
     private BuildInfo buildinfo;
     private ArtifactoryServer server;
     private StepContext context;
+    private int deployRetryCount;
 
-    public GenericUploadExecutor(ArtifactoryServer server, TaskListener listener, Run build, FilePath ws, BuildInfo buildInfo, StepContext context) {
+    public GenericUploadExecutor(ArtifactoryServer server, TaskListener listener, Run build, FilePath ws, BuildInfo buildInfo, StepContext context, int deployRetryCount) {
         this.server = server;
         this.listener = listener;
         this.build = build;
         this.buildinfo = Utils.prepareBuildinfo(build, buildInfo);
         this.ws = ws;
         this.context = context;
+        this.deployRetryCount = deployRetryCount;
     }
 
     public BuildInfo execution(String spec) throws IOException, InterruptedException {
@@ -50,7 +52,7 @@ public class GenericUploadExecutor {
                 server.getDeployerCredentialsConfig().providePassword(build.getParent()));
         ProxyConfiguration proxyConfiguration = server.createProxyConfiguration(Jenkins.getInstance().proxy);
         List<Artifact> artifactsToDeploy = ws.act(new GenericArtifactsDeployer.FilesDeployerCallable(listener, spec,
-                server, credentials, getPropertiesMap(), proxyConfiguration));
+                server, credentials, getPropertiesMap(), proxyConfiguration, deployRetryCount));
         new BuildInfoAccessor(buildinfo).appendDeployedArtifacts(artifactsToDeploy);
         return buildinfo;
     }

--- a/src/main/java/org/jfrog/hudson/pipeline/steps/UploadStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/UploadStep.java
@@ -23,12 +23,14 @@ public class UploadStep extends AbstractStepImpl {
     private BuildInfo buildInfo;
     private String spec;
     private ArtifactoryServer server;
+    private int deployRetryCount;
 
     @DataBoundConstructor
-    public UploadStep(String spec, BuildInfo buildInfo, ArtifactoryServer server) {
+    public UploadStep(String spec, BuildInfo buildInfo, ArtifactoryServer server, int deployRetryCount) {
         this.spec = spec;
         this.buildInfo = buildInfo;
         this.server = server;
+        this.deployRetryCount = deployRetryCount;
     }
 
     public BuildInfo getBuildInfo() {
@@ -41,6 +43,10 @@ public class UploadStep extends AbstractStepImpl {
 
     public ArtifactoryServer getServer() {
         return server;
+    }
+
+    public int getDeployRetryCount() {
+        return deployRetryCount;
     }
 
     public static class Execution extends AbstractSynchronousNonBlockingStepExecution<BuildInfo> {
@@ -62,7 +68,7 @@ public class UploadStep extends AbstractStepImpl {
 
         @Override
         protected BuildInfo run() throws Exception {
-            BuildInfo buildInfo = new GenericUploadExecutor(Utils.prepareArtifactoryServer(null, step.getServer()), listener, build, ws, step.getBuildInfo(), getContext()).execution(Util.replaceMacro(step.getSpec(), env));
+            BuildInfo buildInfo = new GenericUploadExecutor(Utils.prepareArtifactoryServer(null, step.getServer()), listener, build, ws, step.getBuildInfo(), getContext(),step.getDeployRetryCount()).execution(Util.replaceMacro(step.getSpec(), env));
             new BuildInfoAccessor(buildInfo).captureVariables(env, build, listener);
             return buildInfo;
         }

--- a/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
@@ -92,6 +92,14 @@
         </f:block>
 
         <f:block>
+            <table style="width:100%" id="retryDeploymentArea">
+                <f:entry title="Retry deployment">
+                    <f:number clazz="number" name="deployRetryCount" value="${instance.deployRetryCount}" min="0" step="1"/>
+                </f:entry>
+            </table>
+        </f:block>
+
+        <f:block>
             <table style="width:100%; " id="uploadSpecArea">
                 <f:dropdownList name="uploadSpec" title="${%Upload spec source}" help="/plugin/artifactory/help/common/help-UploadSpec.html">
 


### PR DESCRIPTION
This was done to work around occasional deployment errors 500 and random network issues.
The variable deployRetryCount name is called this way to resemble the retry count variable from jenkins SCM context: https://jenkinsci.github.io/job-dsl-plugin/#method/javaposse.jobdsl.dsl.jobs.MatrixJob.checkoutRetryCount