### PR TITLE
Introduce Jenkinsfile with buildPlugin() call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin()


### PR DESCRIPTION
### Background
This plugin is built on [old Jenkins](https://jenkins.ci.cloudbees.com/) which is deprecated already.
![image](https://user-images.githubusercontent.com/3036347/34412698-5df44812-ebe7-11e7-824e-3e78044d26eb.png)


### What has been done
Added `Jenkinsfile` with default configuration. By default, plugin will be built on `linux` and `windows` (in parallel).
More info about `buildPlugin` can be found [here](https://github.com/jenkins-infra/pipeline-library/blob/master/README.adoc#buildplugin).

### What needs to be done by admin

Webhooks in repository settings should be configured:
- https://jenkins.ci.cloudbees.com/github-webhook/ for "Just push event" event (ideally, only this one should be enough)
- https://jenkins.ci.cloudbees.com/github-pull-request-hook/ for "Pull request" event