### PR TITLE
Add matrix-project dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
             <version>2.10.1</version>
             <optional>true</optional>


### PR DESCRIPTION
Many classes have a dependency on matrix project but it is not declared as a direct dependency in pom.xml. Older versions worked because other dependencies brought matrix-project as a trainsient dependency but it changed. Now jenkins plugin manager install artifactory without installing matrix project plugin and any job configuration fails with hudson/matrix/MatrixProject class not found.