### PR TITLE
Append /bin/gradle to existing GRADLE_HOME path

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/steps/ArtifactoryGradleBuild.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/ArtifactoryGradleBuild.java
@@ -228,7 +228,7 @@ public class ArtifactoryGradleBuild extends AbstractStepImpl {
             if (extendedEnv.get("GRADLE_HOME") == null) {
                 throw new RuntimeException("Couldn't find gradle installation");
             }
-            return extendedEnv.get("GRADLE_HOME");
+            return extendedEnv.get("GRADLE_HOME") + "/bin/gradle";
         }
 
         private String createInitScript() throws Exception {


### PR DESCRIPTION
When using an existing Gradle installation, executing the plugin results in a 'No such file or directory' error...
Shouldn't the return value of getGradleExe() point to the gradle executable instead of just GRADLE_HOME?