### PR TITLE
[JENKINS-55224] Replace JGit Repository.getRef() call

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/Utils.java
@@ -18,8 +18,7 @@ import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.jgit.internal.storage.file.FileRepository;
-import org.eclipse.jgit.lib.Ref;
+import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jfrog.build.api.BuildInfoFields;
@@ -140,9 +139,7 @@ public class Utils {
         if (dotGitPath.exists()) {
             return dotGitPath.act(new MasterToSlaveFileCallable<String>() {
                 public String invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
-                    FileRepository repository = new FileRepository(f);
-                    Ref head = repository.getRef("HEAD");
-                    return head.getObjectId().getName();
+                    return Git.with(TaskListener.NULL, new EnvVars()).in(f).getClient().revParse("HEAD").getName();
                 }
             });
         }


### PR DESCRIPTION
The JGit project replaced the JGit 4 Repository.getRef(String) method with Repository.exactRef(String) and Repository.findRef(String) in JGit 5. The getRef(String) method was removed from JGit 5.2.

JGit compatibility does not provide the same upgrade path as Jenkins compatibility. The removal of the getRef(String) API will break Jenkins plugins that depend on git client plugin prior to 3.0. The simplest solution seems to be to find and replace all calls to Repository.getRef() with an equivalent call to the Jenkins git client plugin.

Key issues before this pull request:

* Class not found exception when this plugin calls Repository.getRef() in git client plugin 3.0.0-beta6
* Can't use Repository.getRef() with git client plugin 3.0.
* Can't use Repository.exactRef() with git client plugin before 3.0.

Solution:

* Use Jenkins git client plugin and let it call the correct JGit method