### PR TITLE
Removed required target repo

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/PromoteBuildStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/steps/PromoteBuildStep.java
@@ -61,11 +61,6 @@ public class PromoteBuildStep extends AbstractStepImpl {
                 return false;
             }
 
-            if (StringUtils.isEmpty(promotionConfig.getTargetRepo())) {
-                getContext().onFailure(new MissingArgumentException("Promotion target repository is mandatory"));
-                return false;
-            }
-
             new PromotionExecutor(Utils.prepareArtifactoryServer(null, step.getServer()), build, listener, getContext(), promotionConfig).execute();
             return true;
         }


### PR DESCRIPTION
Since the REST API supports not supplying a target repo, and additionally the recently added Declarative [PromoteBuildStep](https://github.com/jenkinsci/artifactory-plugin/blob/master/src/main/java/org/jfrog/hudson/pipeline/declarative/steps/PromoteBuildStep.java) supports not supplying it, I see no reason that it has to be required in the Scripted PromoteBuildStep.