### PR TITLE
Added <br/> for Artifactory Build Info page

### DIFF
--- a/src/main/resources/org/jfrog/hudson/BuildInfoResultAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/BuildInfoResultAction/index.jelly
@@ -19,6 +19,7 @@
                             <a href="${publishedBuildDetails.buildInfoUrl}" target="_blank">
                                 ${publishedBuildDetails.displayName}
                             </a>
+                            <br/>
                         </td>
                     </tr>
                 </j:forEach>


### PR DESCRIPTION
With Jenkins 2.277 UI change from html table layout to html div markup. Since then published builds are arranged in a single line in the "Artifactory Build Info" View of Jenkins -> really bad view!

Added a <br/> -> Quick solution, works.

