### PR TITLE
Use Eclipse Temurin, not AdoptOpenJDK in action

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -8,10 +8,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.0.0
         with:
           java-version: "8"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Configure Linux runner
         run: echo "MAVEN_HOME=$(whereis mvn)" >> $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,10 @@ jobs:
           node-version: "16"
 
       - name: Install Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.0.0
         with:
           java-version: "8"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Install NuGet
         uses: nuget/setup-nuget@v1


### PR DESCRIPTION
The 'adopt' distribution has moved to Eclipse Temurin.

It won't be updated at the AdoptOpenJDK location.

See https://github.com/jenkinsci/jenkins/pull/6406

https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#adopt

https://github.com/actions/setup-java#usage

Superseded by https://github.com/jfrog/jenkins-artifactory-plugin/pull/657