### PR TITLE
deprecate the jenkins artifactory plugin

### DIFF
--- a/.github/workflows/monitorIssues.yml
+++ b/.github/workflows/monitorIssues.yml
@@ -1,0 +1,35 @@
+name: Monitor Issues
+on:
+  workflow_dispatch:
+    inputs:
+      operations-per-run:
+        description: 'Number of operations per run'
+        required: false
+        default: '30'
+  schedule:
+    - cron: "0 0 * * *"  # Runs once a day at midnight
+jobs:
+  monitor-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Ignore issues with these labels
+          exempt-issue-labels: 'feature request,question'
+          # Days of inactivity before marking an issue as stale
+          days-before-issue-stale: 180
+          # Days of inactivity before closing an issue
+          days-before-issue-close: 7
+          # Name of the stale label
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has been marked as stale due to 6 months of inactivity. As part of our effort to address every issue properly, please feel free to remove the stale label or keep this issue active by leaving a comment. Otherwise, it will be closed in 7 days"
+          close-issue-message: "This issue was closed due to 7 days of inactivity after being marked as stale. Feel free to reopen it if it remains relevant."
+          # Ignore pull requests
+          days-before-pr-close: false
+          days-before-pr-stale: false
+          ascending: true
+          # Get from input or resolve to default
+          operations-per-run: ${{ github.event.inputs.operations-per-run || '30' }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@
 
 </div>
 
+> ## This plugin is deprecated
+>
+> The Jenkins Artifactory Plugin is no longer the recommended way to integrate
+> Jenkins with the JFrog Platform. New functionality is going only into the
+> **[JFrog Plugin](https://plugins.jenkins.io/jfrog/)**, which wraps the
+> [JFrog CLI](https://jfrog.com/getcli/).
+>
+> - **Existing installations continue to work.** 
+> - **For new pipelines**, install the JFrog plugin and follow the
+>   [migration guide](https://docs.jfrog-applications.jfrog.io/ci-and-sdks/ci-integrations/jenkins-jfrog-plugin).
+
 ## General
 
 The plugin integrates Jenkins and Artifactory to publish, resolve, promote and release traceable build artifacts. For

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <version>4.0.x-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Jenkins Artifactory Plugin</name>
-    <description>Integrates Artifactory to Jenkins</description>
+    <description>[Deprecated — Integrates Artifactory to Jenkins.</description>
     <url>https://github.com/jenkinsci/artifactory-plugin</url>
 
     <properties>

--- a/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryBuilder.java
@@ -61,7 +61,9 @@ import static org.jfrog.hudson.util.ProxyUtils.createProxyConfiguration;
 
 /**
  * @author Yossi Shaul
+ * @deprecated The Jenkins Artifactory Plugin is deprecated.
  */
+@Deprecated
 public class ArtifactoryBuilder extends GlobalConfiguration {
 
     /**

--- a/src/main/java/org/jfrog/hudson/ArtifactoryRedeployPublisher.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryRedeployPublisher.java
@@ -55,8 +55,10 @@ import java.util.*;
  * is fully succeeded.
  *
  * @author Yossi Shaul
+ * @deprecated The Jenkins Artifactory Plugin is deprecated.
  */
 
+@Deprecated
 public class ArtifactoryRedeployPublisher extends Recorder implements DeployerOverrider, BuildInfoAwareConfigurator {
     /**
      * Deploy even if the build is unstable (failed tests)

--- a/src/main/java/org/jfrog/hudson/ArtifactoryServer.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryServer.java
@@ -50,7 +50,9 @@ import static org.jfrog.hudson.util.ProxyUtils.createProxyConfiguration;
  * Represents an instance of jenkins artifactory configuration page.
  *
  * @author Yossi Shaul
+ * @deprecated The Jenkins Artifactory Plugin is deprecated.
  */
+@Deprecated
 public class ArtifactoryServer implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/dsl/ArtifactoryDSL.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/dsl/ArtifactoryDSL.java
@@ -9,7 +9,10 @@ import javax.annotation.Nonnull;
 
 /**
  * Created by Tamirh on 17/05/2016.
+ *
+ * @deprecated The Jenkins Artifactory Plugin
  */
+@Deprecated
 @Extension
 public class ArtifactoryDSL extends GlobalVariable {
     @Nonnull

--- a/src/main/java/org/jfrog/hudson/pipeline/scripted/dsl/JFrogDSL.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/scripted/dsl/JFrogDSL.java
@@ -7,6 +7,10 @@ import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
 
 import javax.annotation.Nonnull;
 
+/**
+ * @deprecated The Jenkins Artifactory Plugin.
+ */
+@Deprecated
 @Extension
 public class JFrogDSL extends GlobalVariable {
     @Nonnull

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,8 +1,16 @@
 <!--
   This view is used to render the plugin list page.
 
-  Since we don't really have anything dynamic here, let's just use static HTML. 
+  Since we don't really have anything dynamic here, let's just use static HTML.
 -->
 <div>
+    <div style="padding:10px;margin-bottom:10px;border:1px solid #c00;background:#fff5f5;color:#900;">
+        <strong>This plugin is deprecated.</strong>
+        It is no longer the recommended way to integrate Jenkins with the JFrog Platform.
+        Please install the <a href="https://plugins.jenkins.io/jfrog/">JFrog plugin</a>,
+        which wraps the JFrog CLI and receives all new features.
+        Existing installations of this plugin continue to work.
+        See the <a href="https://docs.jfrog-applications.jfrog.io/ci-and-sdks/ci-integrations/jenkins-jfrog-plugin">migration guide</a>.
+    </div>
     This plugin allows your build jobs to deploy artifacts and resolve dependencies to and from Artifactory, and then have them linked to the build job that created them. The plugin includes a vast collection of features, including a rich pipeline API library and release management for Maven and Gradle builds with Staging and Promotion.
 </div>

--- a/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
+++ b/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
@@ -6,6 +6,18 @@
     <st:adjunct includes="lib.jfrog.repos.credentials"/>
     <f:section title="JFrog">
 
+        <f:entry>
+            <div style="padding:10px;border:1px solid #c00;background:#fff5f5;color:#900;">
+                <strong>This plugin (Artifactory) is deprecated.</strong>
+                Please migrate to the
+                <a href="https://plugins.jenkins.io/jfrog/" target="_blank">JFrog plugin</a>,
+                which wraps the JFrog CLI and receives all new features.
+                Existing pipelines continue to work; security.
+                See the
+                <a href="https://docs.jfrog-applications.jfrog.io/ci-and-sdks/ci-integrations/jenkins-jfrog-plugin" target="_blank">migration guide</a>.
+            </div>
+        </f:entry>
+
         <f:entry
                 help="/plugin/artifactory/help/ArtifactoryBuilder/help-useCredentialsPlugin.html">
             <f:checkbox id="useCredentialsPlugin"


### PR DESCRIPTION
- [ ] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----
